### PR TITLE
RISC-V patch series as applied on top of rL308291

### DIFF
--- a/0001-Revert-upstreamed-RISC-V-changes.patch
+++ b/0001-Revert-upstreamed-RISC-V-changes.patch
@@ -6,11 +6,12 @@ This allows the patch series to be maintained and modified on an ongoing
 basis.
 ---
  CMakeLists.txt                                     |   1 -
+ CODE_OWNERS.TXT                                    |   4 -
  docs/CompilerWriterInfo.rst                        |   4 -
  include/llvm/ADT/Triple.h                          |   2 -
+ include/llvm/BinaryFormat/ELF.h                    |   6 -
+ include/llvm/BinaryFormat/ELFRelocs/RISCV.def      |  50 -------
  include/llvm/Object/ELFObjectFile.h                |  13 --
- include/llvm/Support/ELF.h                         |   6 -
- include/llvm/Support/ELFRelocs/RISCV.def           |  50 -------
  include/llvm/module.modulemap                      |   1 -
  lib/Object/ELF.cpp                                 |   7 -
  lib/ObjectYAML/ELFYAML.cpp                         |   4 -
@@ -20,18 +21,18 @@ basis.
  lib/Target/RISCV/LLVMBuild.txt                     |  31 -----
  lib/Target/RISCV/MCTargetDesc/CMakeLists.txt       |   7 -
  lib/Target/RISCV/MCTargetDesc/LLVMBuild.txt        |  23 ----
- lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp  |  91 ------------
+ lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp  |  93 -------------
  .../RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp    |  47 -------
  lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp   |  25 ----
  lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h     |  31 -----
  .../RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp      |  91 ------------
- .../RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp       |  59 --------
+ .../RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp       |  58 --------
  lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h  |  58 --------
  lib/Target/RISCV/RISCV.td                          |  27 ----
- lib/Target/RISCV/RISCVInstrFormats.td              | 152 ---------------------
+ lib/Target/RISCV/RISCVInstrFormats.td              | 153 ---------------------
  lib/Target/RISCV/RISCVInstrInfo.td                 |  55 --------
  lib/Target/RISCV/RISCVRegisterInfo.td              |  90 ------------
- lib/Target/RISCV/RISCVTargetMachine.cpp            |  58 --------
+ lib/Target/RISCV/RISCVTargetMachine.cpp            |  60 --------
  lib/Target/RISCV/RISCVTargetMachine.h              |  40 ------
  lib/Target/RISCV/TargetInfo/CMakeLists.txt         |   3 -
  lib/Target/RISCV/TargetInfo/LLVMBuild.txt          |  23 ----
@@ -39,8 +40,8 @@ basis.
  tools/llvm-objdump/llvm-objdump.cpp                |   1 -
  tools/llvm-readobj/ELFDumper.cpp                   |   1 -
  unittests/ADT/TripleTest.cpp                       |  36 -----
- 34 files changed, 1103 deletions(-)
- delete mode 100644 include/llvm/Support/ELFRelocs/RISCV.def
+ 35 files changed, 1111 deletions(-)
+ delete mode 100644 include/llvm/BinaryFormat/ELFRelocs/RISCV.def
  delete mode 100644 lib/Target/RISCV/CMakeLists.txt
  delete mode 100644 lib/Target/RISCV/LLVMBuild.txt
  delete mode 100644 lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
@@ -63,10 +64,10 @@ basis.
  delete mode 100644 lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index df6ef8efedb..b2e2f7bdfd2 100644
+index 61ecfdf..286b232 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -312,7 +312,6 @@ set(LLVM_ALL_TARGETS
+@@ -325,7 +325,6 @@ set(LLVM_ALL_TARGETS
    MSP430
    NVPTX
    PowerPC
@@ -74,13 +75,28 @@ index df6ef8efedb..b2e2f7bdfd2 100644
    Sparc
    SystemZ
    X86
+diff --git a/CODE_OWNERS.TXT b/CODE_OWNERS.TXT
+index 6198442..07c265e 100644
+--- a/CODE_OWNERS.TXT
++++ b/CODE_OWNERS.TXT
+@@ -14,10 +14,6 @@ E: mail@justinbogner.com
+ D: InstrProfiling and related parts of ProfileData
+ D: SelectionDAG (lib/CodeGen/SelectionDAG/*)
+ 
+-N: Alex Bradbury
+-E: asb@lowrisc.org
+-D: RISC-V backend (lib/Target/RISCV/*)
+-
+ N: Matthias Braun
+ E: matze@braunis.de
+ I: MatzeB
 diff --git a/docs/CompilerWriterInfo.rst b/docs/CompilerWriterInfo.rst
-index 8ce999033b7..6d270e30fc8 100644
+index 24375fb..f100230 100644
 --- a/docs/CompilerWriterInfo.rst
 +++ b/docs/CompilerWriterInfo.rst
-@@ -83,10 +83,6 @@ AMDGPU
- * `AMD Compute Resources <http://developer.amd.com/tools/heterogeneous-computing/amd-accelerated-parallel-processing-app-sdk/documentation/>`_
- * `AMDGPU Compute Application Binary Interface <https://github.com/RadeonOpenCompute/ROCm-ComputeABI-Doc/blob/master/AMDGPU-ABI.md>`__
+@@ -74,10 +74,6 @@ AMDGPU
+ 
+ Refer to :doc:`AMDGPUUsage` for additional documentation.
  
 -RISC-V
 -------
@@ -90,10 +106,10 @@ index 8ce999033b7..6d270e30fc8 100644
  -----
  
 diff --git a/include/llvm/ADT/Triple.h b/include/llvm/ADT/Triple.h
-index ba68ba73c2f..8691d9cdd42 100644
+index cd56065..8f0a215 100644
 --- a/include/llvm/ADT/Triple.h
 +++ b/include/llvm/ADT/Triple.h
-@@ -64,8 +64,6 @@ public:
+@@ -65,8 +65,6 @@ public:
      ppc64le,        // PPC64LE: powerpc64le
      r600,           // R600: AMD GPUs HD2XXX - HD6XXX
      amdgcn,         // AMDGCN: AMD GCN GPUs
@@ -102,49 +118,11 @@ index ba68ba73c2f..8691d9cdd42 100644
      sparc,          // Sparc: sparc
      sparcv9,        // Sparcv9: Sparcv9
      sparcel,        // Sparc: (endianness = little). NB: 'Sparcle' is a CPU variant
-diff --git a/include/llvm/Object/ELFObjectFile.h b/include/llvm/Object/ELFObjectFile.h
-index 9e95f2958aa..c1c0f9ef563 100644
---- a/include/llvm/Object/ELFObjectFile.h
-+++ b/include/llvm/Object/ELFObjectFile.h
-@@ -946,8 +946,6 @@ StringRef ELFObjectFile<ELFT>::getFileFormatName() const {
-       return "ELF32-mips";
-     case ELF::EM_PPC:
-       return "ELF32-ppc";
--    case ELF::EM_RISCV:
--      return "ELF32-riscv";
-     case ELF::EM_SPARC:
-     case ELF::EM_SPARC32PLUS:
-       return "ELF32-sparc";
-@@ -968,8 +966,6 @@ StringRef ELFObjectFile<ELFT>::getFileFormatName() const {
-       return (IsLittleEndian ? "ELF64-aarch64-little" : "ELF64-aarch64-big");
-     case ELF::EM_PPC64:
-       return "ELF64-ppc64";
--    case ELF::EM_RISCV:
--      return "ELF64-riscv";
-     case ELF::EM_S390:
-       return "ELF64-s390";
-     case ELF::EM_SPARCV9:
-@@ -1025,15 +1021,6 @@ unsigned ELFObjectFile<ELFT>::getArch() const {
-     return Triple::ppc;
-   case ELF::EM_PPC64:
-     return IsLittleEndian ? Triple::ppc64le : Triple::ppc64;
--  case ELF::EM_RISCV:
--    switch (EF.getHeader()->e_ident[ELF::EI_CLASS]) {
--    case ELF::ELFCLASS32:
--      return Triple::riscv32;
--    case ELF::ELFCLASS64:
--      return Triple::riscv64;
--    default:
--      report_fatal_error("Invalid ELFCLASS!");
--    }
-   case ELF::EM_S390:
-     return Triple::systemz;
- 
-diff --git a/include/llvm/Support/ELF.h b/include/llvm/Support/ELF.h
-index dad9c2f990b..fa0acf2a295 100644
---- a/include/llvm/Support/ELF.h
-+++ b/include/llvm/Support/ELF.h
-@@ -307,7 +307,6 @@ enum {
+diff --git a/include/llvm/BinaryFormat/ELF.h b/include/llvm/BinaryFormat/ELF.h
+index a4450ee..6d0d039 100644
+--- a/include/llvm/BinaryFormat/ELF.h
++++ b/include/llvm/BinaryFormat/ELF.h
+@@ -309,7 +309,6 @@ enum {
    EM_NORC = 218,          // Nanoradio Optimized RISC
    EM_CSR_KALIMBA = 219,   // CSR Kalimba architecture family
    EM_AMDGPU = 224,        // AMD GPU architecture
@@ -152,7 +130,7 @@ index dad9c2f990b..fa0acf2a295 100644
    EM_LANAI = 244,         // Lanai 32-bit processor
    EM_BPF = 247,           // Linux kernel bpf virtual machine
  
-@@ -589,11 +588,6 @@ enum {
+@@ -591,11 +590,6 @@ enum {
  #include "ELFRelocs/Lanai.def"
  };
  
@@ -164,10 +142,10 @@ index dad9c2f990b..fa0acf2a295 100644
  // ELF Relocation types for S390/zSeries
  enum {
  #include "ELFRelocs/SystemZ.def"
-diff --git a/include/llvm/Support/ELFRelocs/RISCV.def b/include/llvm/Support/ELFRelocs/RISCV.def
+diff --git a/include/llvm/BinaryFormat/ELFRelocs/RISCV.def b/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
 deleted file mode 100644
-index 9ec4955d26d..00000000000
---- a/include/llvm/Support/ELFRelocs/RISCV.def
+index 9ec4955..0000000
+--- a/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
 +++ /dev/null
 @@ -1,50 +0,0 @@
 -
@@ -220,41 +198,79 @@ index 9ec4955d26d..00000000000
 -ELF_RELOC(R_RISCV_RVC_LUI,           46)
 -ELF_RELOC(R_RISCV_GPREL_I,           47)
 -ELF_RELOC(R_RISCV_GPREL_S,           48)
+diff --git a/include/llvm/Object/ELFObjectFile.h b/include/llvm/Object/ELFObjectFile.h
+index 73011f6..5b5b175 100644
+--- a/include/llvm/Object/ELFObjectFile.h
++++ b/include/llvm/Object/ELFObjectFile.h
+@@ -958,8 +958,6 @@ StringRef ELFObjectFile<ELFT>::getFileFormatName() const {
+       return "ELF32-mips";
+     case ELF::EM_PPC:
+       return "ELF32-ppc";
+-    case ELF::EM_RISCV:
+-      return "ELF32-riscv";
+     case ELF::EM_SPARC:
+     case ELF::EM_SPARC32PLUS:
+       return "ELF32-sparc";
+@@ -980,8 +978,6 @@ StringRef ELFObjectFile<ELFT>::getFileFormatName() const {
+       return (IsLittleEndian ? "ELF64-aarch64-little" : "ELF64-aarch64-big");
+     case ELF::EM_PPC64:
+       return "ELF64-ppc64";
+-    case ELF::EM_RISCV:
+-      return "ELF64-riscv";
+     case ELF::EM_S390:
+       return "ELF64-s390";
+     case ELF::EM_SPARCV9:
+@@ -1037,15 +1033,6 @@ unsigned ELFObjectFile<ELFT>::getArch() const {
+     return Triple::ppc;
+   case ELF::EM_PPC64:
+     return IsLittleEndian ? Triple::ppc64le : Triple::ppc64;
+-  case ELF::EM_RISCV:
+-    switch (EF.getHeader()->e_ident[ELF::EI_CLASS]) {
+-    case ELF::ELFCLASS32:
+-      return Triple::riscv32;
+-    case ELF::ELFCLASS64:
+-      return Triple::riscv64;
+-    default:
+-      report_fatal_error("Invalid ELFCLASS!");
+-    }
+   case ELF::EM_S390:
+     return Triple::systemz;
+ 
 diff --git a/include/llvm/module.modulemap b/include/llvm/module.modulemap
-index 29e6d66b27f..5e1d609d76e 100644
+index 766198b..0b936ee 100644
 --- a/include/llvm/module.modulemap
 +++ b/include/llvm/module.modulemap
-@@ -271,7 +271,6 @@ module LLVM_Utils {
-     textual header "Support/ELFRelocs/Mips.def"
-     textual header "Support/ELFRelocs/PowerPC64.def"
-     textual header "Support/ELFRelocs/PowerPC.def"
--    textual header "Support/ELFRelocs/RISCV.def"
-     textual header "Support/ELFRelocs/Sparc.def"
-     textual header "Support/ELFRelocs/SystemZ.def"
-     textual header "Support/ELFRelocs/x86_64.def"
+@@ -56,7 +56,6 @@ module LLVM_BinaryFormat {
+     textual header "BinaryFormat/ELFRelocs/Mips.def"
+     textual header "BinaryFormat/ELFRelocs/PowerPC64.def"
+     textual header "BinaryFormat/ELFRelocs/PowerPC.def"
+-    textual header "BinaryFormat/ELFRelocs/RISCV.def"
+     textual header "BinaryFormat/ELFRelocs/Sparc.def"
+     textual header "BinaryFormat/ELFRelocs/SystemZ.def"
+     textual header "BinaryFormat/ELFRelocs/x86_64.def"
 diff --git a/lib/Object/ELF.cpp b/lib/Object/ELF.cpp
-index 23682e1fabf..4d37a298632 100644
+index 448fb1b..1603d41 100644
 --- a/lib/Object/ELF.cpp
 +++ b/lib/Object/ELF.cpp
-@@ -89,13 +89,6 @@ StringRef getELFRelocationTypeName(uint32_t Machine, uint32_t Type) {
+@@ -93,13 +93,6 @@ StringRef llvm::object::getELFRelocationTypeName(uint32_t Machine,
        break;
      }
      break;
 -  case ELF::EM_RISCV:
 -    switch (Type) {
--#include "llvm/Support/ELFRelocs/RISCV.def"
+-#include "llvm/BinaryFormat/ELFRelocs/RISCV.def"
 -    default:
 -      break;
 -    }
 -    break;
    case ELF::EM_S390:
      switch (Type) {
- #include "llvm/Support/ELFRelocs/SystemZ.def"
+ #include "llvm/BinaryFormat/ELFRelocs/SystemZ.def"
 diff --git a/lib/ObjectYAML/ELFYAML.cpp b/lib/ObjectYAML/ELFYAML.cpp
-index 3052901da45..b7de1b7f9d8 100644
+index 39741da..c6cef3e 100644
 --- a/lib/ObjectYAML/ELFYAML.cpp
 +++ b/lib/ObjectYAML/ELFYAML.cpp
-@@ -192,7 +192,6 @@ void ScalarEnumerationTraits<ELFYAML::ELF_EM>::enumeration(
+@@ -198,7 +198,6 @@ void ScalarEnumerationTraits<ELFYAML::ELF_EM>::enumeration(
    ECase(EM_78KOR);
    ECase(EM_56800EX);
    ECase(EM_AMDGPU);
@@ -262,21 +278,21 @@ index 3052901da45..b7de1b7f9d8 100644
    ECase(EM_LANAI);
    ECase(EM_BPF);
  #undef ECase
-@@ -531,9 +530,6 @@ void ScalarEnumerationTraits<ELFYAML::ELF_REL>::enumeration(
+@@ -532,9 +531,6 @@ void ScalarEnumerationTraits<ELFYAML::ELF_REL>::enumeration(
    case ELF::EM_ARM:
- #include "llvm/Support/ELFRelocs/ARM.def"
+ #include "llvm/BinaryFormat/ELFRelocs/ARM.def"
      break;
 -  case ELF::EM_RISCV:
--#include "llvm/Support/ELFRelocs/RISCV.def"
+-#include "llvm/BinaryFormat/ELFRelocs/RISCV.def"
 -    break;
    case ELF::EM_LANAI:
- #include "llvm/Support/ELFRelocs/Lanai.def"
+ #include "llvm/BinaryFormat/ELFRelocs/Lanai.def"
      break;
 diff --git a/lib/Support/Triple.cpp b/lib/Support/Triple.cpp
-index 5c37dfc5ae2..e0138b71b29 100644
+index 2687a67..e42681a 100644
 --- a/lib/Support/Triple.cpp
 +++ b/lib/Support/Triple.cpp
-@@ -39,8 +39,6 @@ StringRef Triple::getArchTypeName(ArchType Kind) {
+@@ -40,8 +40,6 @@ StringRef Triple::getArchTypeName(ArchType Kind) {
    case ppc:            return "powerpc";
    case r600:           return "r600";
    case amdgcn:         return "amdgcn";
@@ -285,7 +301,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case sparc:          return "sparc";
    case sparcv9:        return "sparcv9";
    case sparcel:        return "sparcel";
-@@ -137,9 +135,6 @@ StringRef Triple::getArchTypePrefix(ArchType Kind) {
+@@ -140,9 +138,6 @@ StringRef Triple::getArchTypePrefix(ArchType Kind) {
    case shave:       return "shave";
    case wasm32:
    case wasm64:      return "wasm";
@@ -295,7 +311,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    }
  }
  
-@@ -267,8 +262,6 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
+@@ -273,8 +268,6 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
      .Case("ppc64le", ppc64le)
      .Case("r600", r600)
      .Case("amdgcn", amdgcn)
@@ -304,8 +320,8 @@ index 5c37dfc5ae2..e0138b71b29 100644
      .Case("hexagon", hexagon)
      .Case("sparc", sparc)
      .Case("sparcel", sparcel)
-@@ -385,8 +378,6 @@ static Triple::ArchType parseArch(StringRef ArchName) {
-     .Case("mips64el", Triple::mips64el)
+@@ -392,8 +385,6 @@ static Triple::ArchType parseArch(StringRef ArchName) {
+     .Case("nios2", Triple::nios2)
      .Case("r600", Triple::r600)
      .Case("amdgcn", Triple::amdgcn)
 -    .Case("riscv32", Triple::riscv32)
@@ -313,7 +329,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
      .Case("hexagon", Triple::hexagon)
      .Cases("s390x", "systemz", Triple::systemz)
      .Case("sparc", Triple::sparc)
-@@ -629,8 +620,6 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
+@@ -639,8 +630,6 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
    case Triple::r600:
    case Triple::renderscript32:
    case Triple::renderscript64:
@@ -322,7 +338,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::shave:
    case Triple::sparc:
    case Triple::sparcel:
-@@ -1159,7 +1148,6 @@ static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
+@@ -1176,7 +1165,6 @@ static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
    case llvm::Triple::nvptx:
    case llvm::Triple::ppc:
    case llvm::Triple::r600:
@@ -330,7 +346,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case llvm::Triple::sparc:
    case llvm::Triple::sparcel:
    case llvm::Triple::tce:
-@@ -1189,7 +1177,6 @@ static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
+@@ -1206,7 +1194,6 @@ static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
    case llvm::Triple::nvptx64:
    case llvm::Triple::ppc64:
    case llvm::Triple::ppc64le:
@@ -338,7 +354,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case llvm::Triple::sparcv9:
    case llvm::Triple::systemz:
    case llvm::Triple::x86_64:
-@@ -1242,7 +1229,6 @@ Triple Triple::get32BitArchVariant() const {
+@@ -1260,7 +1247,6 @@ Triple Triple::get32BitArchVariant() const {
    case Triple::nvptx:
    case Triple::ppc:
    case Triple::r600:
@@ -346,7 +362,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::sparc:
    case Triple::sparcel:
    case Triple::tce:
-@@ -1266,7 +1252,6 @@ Triple Triple::get32BitArchVariant() const {
+@@ -1284,7 +1270,6 @@ Triple Triple::get32BitArchVariant() const {
    case Triple::nvptx64:        T.setArch(Triple::nvptx);   break;
    case Triple::ppc64:          T.setArch(Triple::ppc);     break;
    case Triple::sparcv9:        T.setArch(Triple::sparc);   break;
@@ -354,7 +370,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::x86_64:         T.setArch(Triple::x86);     break;
    case Triple::amdil64:        T.setArch(Triple::amdil);   break;
    case Triple::hsail64:        T.setArch(Triple::hsail);   break;
-@@ -1309,7 +1294,6 @@ Triple Triple::get64BitArchVariant() const {
+@@ -1328,7 +1313,6 @@ Triple Triple::get64BitArchVariant() const {
    case Triple::nvptx64:
    case Triple::ppc64:
    case Triple::ppc64le:
@@ -362,7 +378,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::sparcv9:
    case Triple::systemz:
    case Triple::x86_64:
-@@ -1326,7 +1310,6 @@ Triple Triple::get64BitArchVariant() const {
+@@ -1345,7 +1329,6 @@ Triple Triple::get64BitArchVariant() const {
    case Triple::nvptx:           T.setArch(Triple::nvptx64);    break;
    case Triple::ppc:             T.setArch(Triple::ppc64);      break;
    case Triple::sparc:           T.setArch(Triple::sparcv9);    break;
@@ -370,7 +386,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::x86:             T.setArch(Triple::x86_64);     break;
    case Triple::amdil:           T.setArch(Triple::amdil64);    break;
    case Triple::hsail:           T.setArch(Triple::hsail64);    break;
-@@ -1360,8 +1343,6 @@ Triple Triple::getBigEndianArchVariant() const {
+@@ -1380,8 +1363,6 @@ Triple Triple::getBigEndianArchVariant() const {
    case Triple::nvptx64:
    case Triple::nvptx:
    case Triple::r600:
@@ -379,7 +395,7 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::shave:
    case Triple::spir64:
    case Triple::spir:
-@@ -1447,8 +1428,6 @@ bool Triple::isLittleEndian() const {
+@@ -1468,8 +1449,6 @@ bool Triple::isLittleEndian() const {
    case Triple::nvptx:
    case Triple::ppc64le:
    case Triple::r600:
@@ -389,12 +405,12 @@ index 5c37dfc5ae2..e0138b71b29 100644
    case Triple::sparcel:
    case Triple::spir64:
 diff --git a/lib/Target/LLVMBuild.txt b/lib/Target/LLVMBuild.txt
-index 8be2a898e38..43621629dd2 100644
+index 34b966d..c6794ab 100644
 --- a/lib/Target/LLVMBuild.txt
 +++ b/lib/Target/LLVMBuild.txt
-@@ -30,7 +30,6 @@ subdirectories =
-  NVPTX
+@@ -31,7 +31,6 @@ subdirectories =
   Mips
+  Nios2
   PowerPC
 - RISCV
   Sparc
@@ -402,7 +418,7 @@ index 8be2a898e38..43621629dd2 100644
   WebAssembly
 diff --git a/lib/Target/RISCV/CMakeLists.txt b/lib/Target/RISCV/CMakeLists.txt
 deleted file mode 100644
-index c8887548b91..00000000000
+index c888754..0000000
 --- a/lib/Target/RISCV/CMakeLists.txt
 +++ /dev/null
 @@ -1,14 +0,0 @@
@@ -422,7 +438,7 @@ index c8887548b91..00000000000
 -add_subdirectory(MCTargetDesc)
 diff --git a/lib/Target/RISCV/LLVMBuild.txt b/lib/Target/RISCV/LLVMBuild.txt
 deleted file mode 100644
-index 9ba5fec928f..00000000000
+index 9ba5fec..0000000
 --- a/lib/Target/RISCV/LLVMBuild.txt
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -459,7 +475,7 @@ index 9ba5fec928f..00000000000
 -add_to_library_groups = RISCV
 diff --git a/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt b/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
 deleted file mode 100644
-index d79de74f7cf..00000000000
+index d79de74..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
 +++ /dev/null
 @@ -1,7 +0,0 @@
@@ -472,7 +488,7 @@ index d79de74f7cf..00000000000
 -)
 diff --git a/lib/Target/RISCV/MCTargetDesc/LLVMBuild.txt b/lib/Target/RISCV/MCTargetDesc/LLVMBuild.txt
 deleted file mode 100644
-index e48f04963ff..00000000000
+index e48f049..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/LLVMBuild.txt
 +++ /dev/null
 @@ -1,23 +0,0 @@
@@ -501,10 +517,10 @@ index e48f04963ff..00000000000
 -add_to_library_groups = RISCV
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp b/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
 deleted file mode 100644
-index f8ef142255c..00000000000
+index be83efc..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
 +++ /dev/null
-@@ -1,91 +0,0 @@
+@@ -1,93 +0,0 @@
 -//===-- RISCVAsmBackend.cpp - RISCV Assembler Backend ---------------------===//
 -//
 -//                     The LLVM Compiler Infrastructure
@@ -519,10 +535,10 @@ index f8ef142255c..00000000000
 -#include "llvm/MC/MCAssembler.h"
 -#include "llvm/MC/MCDirectives.h"
 -#include "llvm/MC/MCELFObjectWriter.h"
+-#include "llvm/MC/MCExpr.h"
 -#include "llvm/MC/MCFixupKindInfo.h"
 -#include "llvm/MC/MCObjectWriter.h"
 -#include "llvm/MC/MCSubtargetInfo.h"
--#include "llvm/MC/MCExpr.h"
 -#include "llvm/MC/MCSymbol.h"
 -#include "llvm/Support/ErrorHandling.h"
 -#include "llvm/Support/raw_ostream.h"
@@ -539,8 +555,9 @@ index f8ef142255c..00000000000
 -      : MCAsmBackend(), OSABI(OSABI), Is64Bit(Is64Bit) {}
 -  ~RISCVAsmBackend() override {}
 -
--  void applyFixup(const MCFixup &Fixup, char *Data, unsigned DataSize,
--                  uint64_t Value, bool IsPCRel) const override;
+-  void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
+-                  const MCValue &Target, MutableArrayRef<char> Data,
+-                  uint64_t Value, bool IsResolved) const override;
 -
 -  MCObjectWriter *createObjectWriter(raw_pwrite_stream &OS) const override;
 -
@@ -576,9 +593,10 @@ index f8ef142255c..00000000000
 -  return true;
 -}
 -
--void RISCVAsmBackend::applyFixup(const MCFixup &Fixup, char *Data,
--                                 unsigned DataSize, uint64_t Value,
--                                 bool IsPCRel) const {
+-void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
+-                                 const MCValue &Target,
+-                                 MutableArrayRef<char> Data, uint64_t Value,
+-                                 bool IsResolved) const {
 -  return;
 -}
 -
@@ -598,7 +616,7 @@ index f8ef142255c..00000000000
 -}
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp b/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
 deleted file mode 100644
-index 4f085d31a26..00000000000
+index 4f085d3..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
 +++ /dev/null
 @@ -1,47 +0,0 @@
@@ -651,7 +669,7 @@ index 4f085d31a26..00000000000
 -}
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp b/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
 deleted file mode 100644
-index b164df8b595..00000000000
+index d622911..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
 +++ /dev/null
 @@ -1,25 +0,0 @@
@@ -675,14 +693,14 @@ index b164df8b595..00000000000
 -void RISCVMCAsmInfo::anchor() {}
 -
 -RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT) {
--  PointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
+-  CodePointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
 -  CommentString = "#";
 -  AlignmentIsInBytes = false;
 -  SupportsDebugInformation = true;
 -}
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h b/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
 deleted file mode 100644
-index 901a1eba8af..00000000000
+index 901a1eb..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
 +++ /dev/null
 @@ -1,31 +0,0 @@
@@ -719,7 +737,7 @@ index 901a1eba8af..00000000000
 -#endif
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp b/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
 deleted file mode 100644
-index b2ed13758d4..00000000000
+index 9309d49..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
 +++ /dev/null
 @@ -1,91 +0,0 @@
@@ -738,13 +756,13 @@ index b2ed13758d4..00000000000
 -
 -#include "MCTargetDesc/RISCVMCTargetDesc.h"
 -#include "llvm/ADT/Statistic.h"
+-#include "llvm/MC/MCAsmInfo.h"
 -#include "llvm/MC/MCCodeEmitter.h"
 -#include "llvm/MC/MCContext.h"
 -#include "llvm/MC/MCExpr.h"
 -#include "llvm/MC/MCInst.h"
 -#include "llvm/MC/MCRegisterInfo.h"
 -#include "llvm/MC/MCSymbol.h"
--#include "llvm/MC/MCAsmInfo.h"
 -#include "llvm/Support/EndianStream.h"
 -#include "llvm/Support/raw_ostream.h"
 -
@@ -816,10 +834,10 @@ index b2ed13758d4..00000000000
 -#include "RISCVGenMCCodeEmitter.inc"
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp b/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
 deleted file mode 100644
-index 4fc69a7fcab..00000000000
+index 41be0a2..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
 +++ /dev/null
-@@ -1,59 +0,0 @@
+@@ -1,58 +0,0 @@
 -//===-- RISCVMCTargetDesc.cpp - RISCV Target Descriptions -----------------===//
 -//
 -//                     The LLVM Compiler Infrastructure
@@ -866,13 +884,12 @@ index 4fc69a7fcab..00000000000
 -
 -static MCAsmInfo *createRISCVMCAsmInfo(const MCRegisterInfo &MRI,
 -                                       const Triple &TT) {
--  MCAsmInfo *MAI = new RISCVMCAsmInfo(TT);
--  return MAI;
+-  return new RISCVMCAsmInfo(TT);
 -}
 -
 -extern "C" void LLVMInitializeRISCVTargetMC() {
 -  for (Target *T : {&getTheRISCV32Target(), &getTheRISCV64Target()}) {
--    RegisterMCAsmInfoFn X(*T, createRISCVMCAsmInfo);
+-    TargetRegistry::RegisterMCAsmInfo(*T, createRISCVMCAsmInfo);
 -    TargetRegistry::RegisterMCInstrInfo(*T, createRISCVMCInstrInfo);
 -    TargetRegistry::RegisterMCRegInfo(*T, createRISCVMCRegisterInfo);
 -    TargetRegistry::RegisterMCAsmBackend(*T, createRISCVAsmBackend);
@@ -881,7 +898,7 @@ index 4fc69a7fcab..00000000000
 -}
 diff --git a/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h b/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
 deleted file mode 100644
-index ddc3bf35045..00000000000
+index 7c98b1c..0000000
 --- a/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
 +++ /dev/null
 @@ -1,58 +0,0 @@
@@ -901,9 +918,9 @@ index ddc3bf35045..00000000000
 -#ifndef LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 -#define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 -
+-#include "llvm/Config/config.h"
 -#include "llvm/MC/MCTargetOptions.h"
 -#include "llvm/Support/DataTypes.h"
--#include "llvm/Config/config.h"
 -
 -namespace llvm {
 -class MCAsmBackend;
@@ -945,7 +962,7 @@ index ddc3bf35045..00000000000
 -#endif
 diff --git a/lib/Target/RISCV/RISCV.td b/lib/Target/RISCV/RISCV.td
 deleted file mode 100644
-index 14838309a1b..00000000000
+index 1483830..0000000
 --- a/lib/Target/RISCV/RISCV.td
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -978,10 +995,10 @@ index 14838309a1b..00000000000
 -}
 diff --git a/lib/Target/RISCV/RISCVInstrFormats.td b/lib/Target/RISCV/RISCVInstrFormats.td
 deleted file mode 100644
-index 1e9bc3bf9bc..00000000000
+index 3fab712..0000000
 --- a/lib/Target/RISCV/RISCVInstrFormats.td
 +++ /dev/null
-@@ -1,152 +0,0 @@
+@@ -1,153 +0,0 @@
 -//===-- RISCVInstrFormats.td - RISCV Instruction Formats ---*- tablegen -*-===//
 -//
 -//                     The LLVM Compiler Infrastructure
@@ -1028,8 +1045,9 @@ index 1e9bc3bf9bc..00000000000
 -
 -// Pseudo instructions
 -class Pseudo<dag outs, dag ins, string asmstr, list<dag> pattern>
--    : RISCVInst<outs, ins, asmstr, pattern> {
+-    : RISCVInst<outs, ins, "", pattern> {
 -  let isPseudo = 1;
+-  let isCodeGenOnly = 1;
 -}
 -
 -class FR<bits<7> funct7, bits<3> funct3, bits<7> opcode, dag outs, dag ins,
@@ -1136,7 +1154,7 @@ index 1e9bc3bf9bc..00000000000
 -}
 diff --git a/lib/Target/RISCV/RISCVInstrInfo.td b/lib/Target/RISCV/RISCVInstrInfo.td
 deleted file mode 100644
-index 52530c2f136..00000000000
+index 52530c2..0000000
 --- a/lib/Target/RISCV/RISCVInstrInfo.td
 +++ /dev/null
 @@ -1,55 +0,0 @@
@@ -1197,7 +1215,7 @@ index 52530c2f136..00000000000
 -
 diff --git a/lib/Target/RISCV/RISCVRegisterInfo.td b/lib/Target/RISCV/RISCVRegisterInfo.td
 deleted file mode 100644
-index f04de217bf0..00000000000
+index f04de21..0000000
 --- a/lib/Target/RISCV/RISCVRegisterInfo.td
 +++ /dev/null
 @@ -1,90 +0,0 @@
@@ -1293,10 +1311,10 @@ index f04de217bf0..00000000000
 -)>;
 diff --git a/lib/Target/RISCV/RISCVTargetMachine.cpp b/lib/Target/RISCV/RISCVTargetMachine.cpp
 deleted file mode 100644
-index afbbe004186..00000000000
+index 744d7b8..0000000
 --- a/lib/Target/RISCV/RISCVTargetMachine.cpp
 +++ /dev/null
-@@ -1,58 +0,0 @@
+@@ -1,60 +0,0 @@
 -//===-- RISCVTargetMachine.cpp - Define TargetMachine for RISCV -----------===//
 -//
 -//                     The LLVM Compiler Infrastructure
@@ -1312,10 +1330,10 @@ index afbbe004186..00000000000
 -
 -#include "RISCVTargetMachine.h"
 -#include "llvm/ADT/STLExtras.h"
+-#include "llvm/CodeGen/Passes.h"
 -#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 -#include "llvm/CodeGen/TargetPassConfig.h"
 -#include "llvm/IR/LegacyPassManager.h"
--#include "llvm/CodeGen/Passes.h"
 -#include "llvm/Support/FormattedStream.h"
 -#include "llvm/Support/TargetRegistry.h"
 -#include "llvm/Target/TargetOptions.h"
@@ -1331,7 +1349,7 @@ index afbbe004186..00000000000
 -    return "e-m:e-i64:64-n32:64-S128";
 -  } else {
 -    assert(TT.isArch32Bit() && "only RV32 and RV64 are currently supported");
--    return "e-m:e-i64:64-n32-S128";
+-    return "e-m:e-p:32:32-i64:64-n32-S128";
 -  }
 -}
 -
@@ -1350,14 +1368,16 @@ index afbbe004186..00000000000
 -                                       CodeGenOpt::Level OL)
 -    : LLVMTargetMachine(T, computeDataLayout(TT), TT, CPU, FS, Options,
 -                        getEffectiveRelocModel(TT, RM), CM, OL),
--      TLOF(make_unique<TargetLoweringObjectFileELF>()) {}
+-      TLOF(make_unique<TargetLoweringObjectFileELF>()) {
+-  initAsmInfo();
+-}
 -
 -TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
--  return new TargetPassConfig(this, PM);
+-  return new TargetPassConfig(*this, PM);
 -}
 diff --git a/lib/Target/RISCV/RISCVTargetMachine.h b/lib/Target/RISCV/RISCVTargetMachine.h
 deleted file mode 100644
-index d13e574c9bf..00000000000
+index d13e574..0000000
 --- a/lib/Target/RISCV/RISCVTargetMachine.h
 +++ /dev/null
 @@ -1,40 +0,0 @@
@@ -1403,7 +1423,7 @@ index d13e574c9bf..00000000000
 -#endif
 diff --git a/lib/Target/RISCV/TargetInfo/CMakeLists.txt b/lib/Target/RISCV/TargetInfo/CMakeLists.txt
 deleted file mode 100644
-index f440fe2cb82..00000000000
+index f440fe2..0000000
 --- a/lib/Target/RISCV/TargetInfo/CMakeLists.txt
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -1412,7 +1432,7 @@ index f440fe2cb82..00000000000
 -  )
 diff --git a/lib/Target/RISCV/TargetInfo/LLVMBuild.txt b/lib/Target/RISCV/TargetInfo/LLVMBuild.txt
 deleted file mode 100644
-index db7f66f94bf..00000000000
+index db7f66f..0000000
 --- a/lib/Target/RISCV/TargetInfo/LLVMBuild.txt
 +++ /dev/null
 @@ -1,23 +0,0 @@
@@ -1441,7 +1461,7 @@ index db7f66f94bf..00000000000
 -add_to_library_groups = RISCV
 diff --git a/lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp b/lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp
 deleted file mode 100644
-index 34932c25915..00000000000
+index 34932c2..0000000
 --- a/lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp
 +++ /dev/null
 @@ -1,30 +0,0 @@
@@ -1476,10 +1496,10 @@ index 34932c25915..00000000000
 -                                    "64-bit RISC-V");
 -}
 diff --git a/tools/llvm-objdump/llvm-objdump.cpp b/tools/llvm-objdump/llvm-objdump.cpp
-index d81cb8878b7..840684beb14 100644
+index d54b455..f0e78b7 100644
 --- a/tools/llvm-objdump/llvm-objdump.cpp
 +++ b/tools/llvm-objdump/llvm-objdump.cpp
-@@ -761,7 +761,6 @@ static std::error_code getRelocationValueString(const ELFObjectFile<ELFT> *Obj,
+@@ -768,7 +768,6 @@ static std::error_code getRelocationValueString(const ELFObjectFile<ELFT> *Obj,
    case ELF::EM_HEXAGON:
    case ELF::EM_MIPS:
    case ELF::EM_BPF:
@@ -1488,10 +1508,10 @@ index d81cb8878b7..840684beb14 100644
      break;
    case ELF::EM_WEBASSEMBLY:
 diff --git a/tools/llvm-readobj/ELFDumper.cpp b/tools/llvm-readobj/ELFDumper.cpp
-index 2ebe44bdcfe..35a685b73a9 100644
+index 5698420..efaf389 100644
 --- a/tools/llvm-readobj/ELFDumper.cpp
 +++ b/tools/llvm-readobj/ELFDumper.cpp
-@@ -949,7 +949,6 @@ static const EnumEntry<unsigned> ElfMachineType[] = {
+@@ -983,7 +983,6 @@ static const EnumEntry<unsigned> ElfMachineType[] = {
    ENUM_ENT(EM_78KOR,         "EM_78KOR"),
    ENUM_ENT(EM_56800EX,       "EM_56800EX"),
    ENUM_ENT(EM_AMDGPU,        "EM_AMDGPU"),
@@ -1500,10 +1520,10 @@ index 2ebe44bdcfe..35a685b73a9 100644
    ENUM_ENT(EM_LANAI,         "EM_LANAI"),
    ENUM_ENT(EM_BPF,           "EM_BPF"),
 diff --git a/unittests/ADT/TripleTest.cpp b/unittests/ADT/TripleTest.cpp
-index 767d9f7248e..9e7a8784ad1 100644
+index 16732c9..0ecdd5e 100644
 --- a/unittests/ADT/TripleTest.cpp
 +++ b/unittests/ADT/TripleTest.cpp
-@@ -266,24 +266,6 @@ TEST(TripleTest, ParsedIDs) {
+@@ -272,24 +272,6 @@ TEST(TripleTest, ParsedIDs) {
    EXPECT_EQ(Triple::AMDHSA, T.getOS());
    EXPECT_EQ(Triple::OpenCL, T.getEnvironment());
  
@@ -1525,10 +1545,10 @@ index 767d9f7248e..9e7a8784ad1 100644
 -  EXPECT_EQ(Triple::FreeBSD, T.getOS());
 -  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
 -
-   T = Triple("huh");
-   EXPECT_EQ(Triple::UnknownArch, T.getArch());
- }
-@@ -577,16 +559,6 @@ TEST(TripleTest, BitWidthPredicates) {
+   T = Triple("armv7hl-suse-linux-gnueabi");
+   EXPECT_EQ(Triple::arm, T.getArch());
+   EXPECT_EQ(Triple::SUSE, T.getVendor());
+@@ -589,16 +571,6 @@ TEST(TripleTest, BitWidthPredicates) {
    EXPECT_FALSE(T.isArch16Bit());
    EXPECT_TRUE(T.isArch32Bit());
    EXPECT_FALSE(T.isArch64Bit());
@@ -1545,7 +1565,7 @@ index 767d9f7248e..9e7a8784ad1 100644
  }
  
  TEST(TripleTest, BitWidthArchVariants) {
-@@ -678,14 +650,6 @@ TEST(TripleTest, BitWidthArchVariants) {
+@@ -690,14 +662,6 @@ TEST(TripleTest, BitWidthArchVariants) {
    EXPECT_EQ(Triple::wasm32, T.get32BitArchVariant().getArch());
    EXPECT_EQ(Triple::wasm64, T.get64BitArchVariant().getArch());
  

--- a/0002-RISCV-Recognise-riscv32-and-riscv64-in-triple-parsin.patch
+++ b/0002-RISCV-Recognise-riscv32-and-riscv64-in-triple-parsin.patch
@@ -56,7 +56,7 @@ index e0138b71b29..5c37dfc5ae2 100644
      .Case("sparc", sparc)
      .Case("sparcel", sparcel)
 @@ -378,6 +385,8 @@ static Triple::ArchType parseArch(StringRef ArchName) {
-     .Case("mips64el", Triple::mips64el)
+     .Case("nios2", Triple::nios2)
      .Case("r600", Triple::r600)
      .Case("amdgcn", Triple::amdgcn)
 +    .Case("riscv32", Triple::riscv32)
@@ -144,8 +144,8 @@ index 9e7a8784ad1..767d9f7248e 100644
 --- a/unittests/ADT/TripleTest.cpp
 +++ b/unittests/ADT/TripleTest.cpp
 @@ -266,6 +266,24 @@ TEST(TripleTest, ParsedIDs) {
-   EXPECT_EQ(Triple::AMDHSA, T.getOS());
-   EXPECT_EQ(Triple::OpenCL, T.getEnvironment());
+   EXPECT_EQ(Triple::Linux, T.getOS());
+   EXPECT_EQ(Triple::GNUEABI, T.getEnvironment());
  
 +  T = Triple("riscv32-unknown-unknown");
 +  EXPECT_EQ(Triple::riscv32, T.getArch());

--- a/0003-RISCV-Add-RISC-V-ELF-defines.patch
+++ b/0003-RISCV-Add-RISC-V-ELF-defines.patch
@@ -11,16 +11,16 @@ Upstream commit: https://reviews.llvm.org/rL285708
 Upstream commit: https://reviews.llvm.org/rL285709
 Upstream commit: https://reviews.llvm.org/rL285730
 ---
- include/llvm/Object/ELFObjectFile.h      | 13 +++++++++
- include/llvm/Support/ELF.h               |  6 ++++
- include/llvm/Support/ELFRelocs/RISCV.def | 50 ++++++++++++++++++++++++++++++++
- include/llvm/module.modulemap            |  1 +
- lib/Object/ELF.cpp                       |  7 +++++
- lib/ObjectYAML/ELFYAML.cpp               |  4 +++
- tools/llvm-objdump/llvm-objdump.cpp      |  1 +
- tools/llvm-readobj/ELFDumper.cpp         |  1 +
+ include/llvm/Object/ELFObjectFile.h           | 13 +++++++++
+ include/llvm/BinaryFormat/ELF.h               |  6 ++++
+ include/llvm/BinaryFormat/ELFRelocs/RISCV.def | 50 ++++++++++++++++++++++++++++++++
+ include/llvm/module.modulemap                 |  1 +
+ lib/Object/ELF.cpp                            |  7 +++++
+ lib/ObjectYAML/ELFYAML.cpp                    |  4 +++
+ tools/llvm-objdump/llvm-objdump.cpp           |  1 +
+ tools/llvm-readobj/ELFDumper.cpp              |  1 +
  8 files changed, 83 insertions(+)
- create mode 100644 include/llvm/Support/ELFRelocs/RISCV.def
+ create mode 100644 include/llvm/BinaryFormat/ELFRelocs/RISCV.def
 
 diff --git a/include/llvm/Object/ELFObjectFile.h b/include/llvm/Object/ELFObjectFile.h
 index c1c0f9ef563..9e95f2958aa 100644
@@ -60,10 +60,10 @@ index c1c0f9ef563..9e95f2958aa 100644
    case ELF::EM_S390:
      return Triple::systemz;
  
-diff --git a/include/llvm/Support/ELF.h b/include/llvm/Support/ELF.h
+diff --git a/include/llvm/BinaryFormat/ELF.h b/include/llvm/BinaryFormat/ELF.h
 index fa0acf2a295..dad9c2f990b 100644
---- a/include/llvm/Support/ELF.h
-+++ b/include/llvm/Support/ELF.h
+--- a/include/llvm/BinaryFormat/ELF.h
++++ b/include/llvm/BinaryFormat/ELF.h
 @@ -307,6 +307,7 @@ enum {
    EM_NORC = 218,          // Nanoradio Optimized RISC
    EM_CSR_KALIMBA = 219,   // CSR Kalimba architecture family
@@ -84,11 +84,11 @@ index fa0acf2a295..dad9c2f990b 100644
  // ELF Relocation types for S390/zSeries
  enum {
  #include "ELFRelocs/SystemZ.def"
-diff --git a/include/llvm/Support/ELFRelocs/RISCV.def b/include/llvm/Support/ELFRelocs/RISCV.def
+diff --git a/include/llvm/BinaryFormat/ELFRelocs/RISCV.def b/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
 new file mode 100644
 index 00000000000..9ec4955d26d
 --- /dev/null
-+++ b/include/llvm/Support/ELFRelocs/RISCV.def
++++ b/include/llvm/BinaryFormat/ELFRelocs/RISCV.def
 @@ -0,0 +1,50 @@
 +
 +#ifndef ELF_RELOC
@@ -145,13 +145,13 @@ index 5e1d609d76e..29e6d66b27f 100644
 --- a/include/llvm/module.modulemap
 +++ b/include/llvm/module.modulemap
 @@ -271,6 +271,7 @@ module LLVM_Utils {
-     textual header "Support/ELFRelocs/Mips.def"
-     textual header "Support/ELFRelocs/PowerPC64.def"
-     textual header "Support/ELFRelocs/PowerPC.def"
-+    textual header "Support/ELFRelocs/RISCV.def"
-     textual header "Support/ELFRelocs/Sparc.def"
-     textual header "Support/ELFRelocs/SystemZ.def"
-     textual header "Support/ELFRelocs/x86_64.def"
+     textual header "BinaryFormat/ELFRelocs/Mips.def"
+     textual header "BinaryFormat/ELFRelocs/PowerPC64.def"
+     textual header "BinaryFormat/ELFRelocs/PowerPC.def"
++    textual header "BinaryFormat/ELFRelocs/RISCV.def"
+     textual header "BinaryFormat/ELFRelocs/Sparc.def"
+     textual header "BinaryFormat/ELFRelocs/SystemZ.def"
+     textual header "BinaryFormat/ELFRelocs/x86_64.def"
 diff --git a/lib/Object/ELF.cpp b/lib/Object/ELF.cpp
 index 4d37a298632..23682e1fabf 100644
 --- a/lib/Object/ELF.cpp
@@ -162,14 +162,14 @@ index 4d37a298632..23682e1fabf 100644
      break;
 +  case ELF::EM_RISCV:
 +    switch (Type) {
-+#include "llvm/Support/ELFRelocs/RISCV.def"
++#include "llvm/BinaryFormat/ELFRelocs/RISCV.def"
 +    default:
 +      break;
 +    }
 +    break;
    case ELF::EM_S390:
      switch (Type) {
- #include "llvm/Support/ELFRelocs/SystemZ.def"
+ #include "llvm/BinaryFormat/ELFRelocs/SystemZ.def"
 diff --git a/lib/ObjectYAML/ELFYAML.cpp b/lib/ObjectYAML/ELFYAML.cpp
 index b7de1b7f9d8..3052901da45 100644
 --- a/lib/ObjectYAML/ELFYAML.cpp
@@ -184,13 +184,13 @@ index b7de1b7f9d8..3052901da45 100644
  #undef ECase
 @@ -530,6 +531,9 @@ void ScalarEnumerationTraits<ELFYAML::ELF_REL>::enumeration(
    case ELF::EM_ARM:
- #include "llvm/Support/ELFRelocs/ARM.def"
+ #include "llvm/BinaryFormat/ELFRelocs/ARM.def"
      break;
 +  case ELF::EM_RISCV:
-+#include "llvm/Support/ELFRelocs/RISCV.def"
++#include "llvm/BinaryFormat/ELFRelocs/RISCV.def"
 +    break;
    case ELF::EM_LANAI:
- #include "llvm/Support/ELFRelocs/Lanai.def"
+ #include "llvm/BinaryFormat/ELFRelocs/Lanai.def"
      break;
 diff --git a/tools/llvm-objdump/llvm-objdump.cpp b/tools/llvm-objdump/llvm-objdump.cpp
 index 840684beb14..d81cb8878b7 100644

--- a/0004-RISCV-Add-stub-backend.patch
+++ b/0004-RISCV-Add-stub-backend.patch
@@ -48,8 +48,8 @@ index 6d270e30fc8..8ce999033b7 100644
 --- a/docs/CompilerWriterInfo.rst
 +++ b/docs/CompilerWriterInfo.rst
 @@ -83,6 +83,10 @@ AMDGPU
- * `AMD Compute Resources <http://developer.amd.com/tools/heterogeneous-computing/amd-accelerated-parallel-processing-app-sdk/documentation/>`_
- * `AMDGPU Compute Application Binary Interface <https://github.com/RadeonOpenCompute/ROCm-ComputeABI-Doc/blob/master/AMDGPU-ABI.md>`__
+ 
+ Refer to :doc:`AMDGPUUsage` for additional documentation.
  
 +RISC-V
 +------
@@ -63,8 +63,8 @@ index 43621629dd2..8be2a898e38 100644
 --- a/lib/Target/LLVMBuild.txt
 +++ b/lib/Target/LLVMBuild.txt
 @@ -30,6 +30,7 @@ subdirectories =
-  NVPTX
   Mips
+  Nios2
   PowerPC
 + RISCV
   Sparc
@@ -139,10 +139,10 @@ index 00000000000..a20331cd0a3
 +
 +#include "RISCVTargetMachine.h"
 +#include "llvm/ADT/STLExtras.h"
++#include "llvm/CodeGen/Passes.h"
 +#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 +#include "llvm/CodeGen/TargetPassConfig.h"
 +#include "llvm/IR/LegacyPassManager.h"
-+#include "llvm/CodeGen/Passes.h"
 +#include "llvm/Support/FormattedStream.h"
 +#include "llvm/Support/TargetRegistry.h"
 +#include "llvm/Target/TargetOptions.h"
@@ -182,7 +182,7 @@ index 00000000000..a20331cd0a3
 +}
 +
 +TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
-+  return new TargetPassConfig(this, PM);
++  return new TargetPassConfig(*this, PM);
 +}
 diff --git a/lib/Target/RISCV/RISCVTargetMachine.h b/lib/Target/RISCV/RISCVTargetMachine.h
 new file mode 100644

--- a/0006-RISCV-Add-bare-bones-RISC-V-MCTargetDesc.patch
+++ b/0006-RISCV-Add-bare-bones-RISC-V-MCTargetDesc.patch
@@ -113,7 +113,7 @@ new file mode 100644
 index 00000000000..f8ef142255c
 --- /dev/null
 +++ b/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,93 @@
 +//===-- RISCVAsmBackend.cpp - RISCV Assembler Backend ---------------------===//
 +//
 +//                     The LLVM Compiler Infrastructure
@@ -128,10 +128,10 @@ index 00000000000..f8ef142255c
 +#include "llvm/MC/MCAssembler.h"
 +#include "llvm/MC/MCDirectives.h"
 +#include "llvm/MC/MCELFObjectWriter.h"
++#include "llvm/MC/MCExpr.h"
 +#include "llvm/MC/MCFixupKindInfo.h"
 +#include "llvm/MC/MCObjectWriter.h"
 +#include "llvm/MC/MCSubtargetInfo.h"
-+#include "llvm/MC/MCExpr.h"
 +#include "llvm/MC/MCSymbol.h"
 +#include "llvm/Support/ErrorHandling.h"
 +#include "llvm/Support/raw_ostream.h"
@@ -148,8 +148,9 @@ index 00000000000..f8ef142255c
 +      : MCAsmBackend(), OSABI(OSABI), Is64Bit(Is64Bit) {}
 +  ~RISCVAsmBackend() override {}
 +
-+  void applyFixup(const MCFixup &Fixup, char *Data, unsigned DataSize,
-+                  uint64_t Value, bool IsPCRel) const override;
++  void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
++                  const MCValue &Target, MutableArrayRef<char> Data,
++                  uint64_t Value, bool IsResolved) const override;
 +
 +  MCObjectWriter *createObjectWriter(raw_pwrite_stream &OS) const override;
 +
@@ -185,9 +186,10 @@ index 00000000000..f8ef142255c
 +  return true;
 +}
 +
-+void RISCVAsmBackend::applyFixup(const MCFixup &Fixup, char *Data,
-+                                 unsigned DataSize, uint64_t Value,
-+                                 bool IsPCRel) const {
++void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
++                                 const MCValue &Target,
++                                 MutableArrayRef<char> Data, uint64_t Value,
++                                 bool IsResolved) const {
 +  return;
 +}
 +
@@ -284,7 +286,7 @@ index 00000000000..b164df8b595
 +void RISCVMCAsmInfo::anchor() {}
 +
 +RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT) {
-+  PointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
++  CodePointerSize = CalleeSaveStackSlotSize = TT.isArch64Bit() ? 8 : 4;
 +  CommentString = "#";
 +  AlignmentIsInBytes = false;
 +  SupportsDebugInformation = true;
@@ -347,13 +349,13 @@ index 00000000000..b2ed13758d4
 +
 +#include "MCTargetDesc/RISCVMCTargetDesc.h"
 +#include "llvm/ADT/Statistic.h"
++#include "llvm/MC/MCAsmInfo.h"
 +#include "llvm/MC/MCCodeEmitter.h"
 +#include "llvm/MC/MCContext.h"
 +#include "llvm/MC/MCExpr.h"
 +#include "llvm/MC/MCInst.h"
 +#include "llvm/MC/MCRegisterInfo.h"
 +#include "llvm/MC/MCSymbol.h"
-+#include "llvm/MC/MCAsmInfo.h"
 +#include "llvm/Support/EndianStream.h"
 +#include "llvm/Support/raw_ostream.h"
 +
@@ -509,9 +511,9 @@ index 00000000000..ddc3bf35045
 +#ifndef LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 +#define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 +
++#include "llvm/Config/config.h"
 +#include "llvm/MC/MCTargetOptions.h"
 +#include "llvm/Support/DataTypes.h"
-+#include "llvm/Config/config.h"
 +
 +namespace llvm {
 +class MCAsmBackend;

--- a/0011-RISCV-Add-common-fixups-and-relocations.patch
+++ b/0011-RISCV-Add-common-fixups-and-relocations.patch
@@ -394,9 +394,10 @@ index f8ef142255c..6455ebbd9cd 100644
 +  }
 +}
 +
- void RISCVAsmBackend::applyFixup(const MCFixup &Fixup, char *Data,
-                                  unsigned DataSize, uint64_t Value,
-                                  bool IsPCRel) const {
+ void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
+                                  const MCValue &Target,
+                                  MutableArrayRef<char> Data, uint64_t Value,
+                                  bool IsResolved) const {
 +  MCFixupKind Kind = Fixup.getKind();
 +  unsigned NumBytes = (getFixupKindInfo(Kind).TargetSize + 7) / 8;
 +  if (!Value)
@@ -409,7 +410,7 @@ index f8ef142255c..6455ebbd9cd 100644
 +  Value <<= Info.TargetOffset;
 +
 +  unsigned Offset = Fixup.getOffset();
-+  assert(Offset + NumBytes <= DataSize && "Invalid fixup offset!");
++  assert(Offset + NumBytes <= Data.size() && "Invalid fixup offset!");
 +
 +  // For each byte of the fragment that the fixup touches, mask in the
 +  // bits from the fixup value.
@@ -570,6 +571,7 @@ index 53b43c92d09..904d4062c6c 100644
 +#include "MCTargetDesc/RISCVMCExpr.h"
  #include "MCTargetDesc/RISCVMCTargetDesc.h"
  #include "llvm/ADT/Statistic.h"
+ #include "llvm/MC/MCAsmInfo.h"
  #include "llvm/MC/MCCodeEmitter.h"
  #include "llvm/MC/MCContext.h"
  #include "llvm/MC/MCExpr.h"
@@ -577,7 +579,6 @@ index 53b43c92d09..904d4062c6c 100644
 +#include "llvm/MC/MCInstrInfo.h"
  #include "llvm/MC/MCRegisterInfo.h"
  #include "llvm/MC/MCSymbol.h"
- #include "llvm/MC/MCAsmInfo.h"
 +#include "llvm/Support/Casting.h"
  #include "llvm/Support/EndianStream.h"
  #include "llvm/Support/raw_ostream.h"

--- a/0012-RISCV-Initial-codegen-support-for-ALU-operations.patch
+++ b/0012-RISCV-Initial-codegen-support-for-ALU-operations.patch
@@ -1152,11 +1152,10 @@ index a20331cd0a3..6e1be40eff9 100644
 +#include "RISCV.h"
  #include "RISCVTargetMachine.h"
  #include "llvm/ADT/STLExtras.h"
-+#include "llvm/CodeGen/Passes.h"
+ #include "llvm/CodeGen/Passes.h"
  #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
  #include "llvm/CodeGen/TargetPassConfig.h"
  #include "llvm/IR/LegacyPassManager.h"
--#include "llvm/CodeGen/Passes.h"
  #include "llvm/Support/FormattedStream.h"
  #include "llvm/Support/TargetRegistry.h"
  #include "llvm/Target/TargetOptions.h"
@@ -1173,7 +1172,7 @@ index a20331cd0a3..6e1be40eff9 100644
 +namespace {
 +class RISCVPassConfig : public TargetPassConfig {
 +public:
-+  RISCVPassConfig(RISCVTargetMachine *TM, PassManagerBase &PM)
++  RISCVPassConfig(RISCVTargetMachine &TM, PassManagerBase &PM)
 +      : TargetPassConfig(TM, PM) {}
 +
 +  RISCVTargetMachine &getRISCVTargetMachine() const {
@@ -1185,8 +1184,8 @@ index a20331cd0a3..6e1be40eff9 100644
 +}
 +
  TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
--  return new TargetPassConfig(this, PM);
-+  return new RISCVPassConfig(this, PM);
+-  return new TargetPassConfig(*this, PM);
++  return new RISCVPassConfig(*this, PM);
 +}
 +
 +bool RISCVPassConfig::addInstSelector() {

--- a/0013-RISCV-Codegen-support-for-memory-operations.patch
+++ b/0013-RISCV-Codegen-support-for-memory-operations.patch
@@ -462,8 +462,8 @@ index 00000000000..396498ebcd0
 +
 +define i32 @lb(i8 *%a) nounwind {
 +; CHECK-LABEL: lb:
-+; CHECK: lb {{[a-z0-9]+}}, 1(a0)
 +; CHECK: lb {{[a-z0-9]+}}, 0(a0)
++; CHECK: lb {{[a-z0-9]+}}, 1(a0)
 +  %1 = getelementptr i8, i8* %a, i32 1
 +  %2 = load i8, i8* %1
 +  %3 = sext i8 %2 to i32
@@ -474,8 +474,8 @@ index 00000000000..396498ebcd0
 +
 +define i32 @lh(i16 *%a) nounwind {
 +; CHECK-LABEL: lh:
-+; CHECK: lh {{[a-z0-9]+}}, 4(a0)
 +; CHECK: lh {{[a-z0-9]+}}, 0(a0)
++; CHECK: lh {{[a-z0-9]+}}, 4(a0)
 +  %1 = getelementptr i16, i16* %a, i32 2
 +  %2 = load i16, i16* %1
 +  %3 = sext i16 %2 to i32
@@ -486,8 +486,8 @@ index 00000000000..396498ebcd0
 +
 +define i32 @lw(i32 *%a) nounwind {
 +; CHECK-LABEL: lw:
-+; CHECK: lw {{[a-z0-9]+}}, 12(a0)
 +; CHECK: lw {{[a-z0-9]+}}, 0(a0)
++; CHECK: lw {{[a-z0-9]+}}, 12(a0)
 +  %1 = getelementptr i32, i32* %a, i32 3
 +  %2 = load i32, i32* %1
 +  %3 = load volatile i32, i32* %a
@@ -496,8 +496,8 @@ index 00000000000..396498ebcd0
 +
 +define i32 @lbu(i8 *%a) nounwind {
 +; CHECK-LABEL: lbu:
-+; CHECK: lbu {{[a-z0-9]+}}, 4(a0)
 +; CHECK: lbu {{[a-z0-9]+}}, 0(a0)
++; CHECK: lbu {{[a-z0-9]+}}, 4(a0)
 +  %1 = getelementptr i8, i8* %a, i32 4
 +  %2 = load i8, i8* %1
 +  %3 = zext i8 %2 to i32
@@ -509,8 +509,8 @@ index 00000000000..396498ebcd0
 +
 +define i32 @lhu(i16 *%a) nounwind {
 +; CHECK-LABEL: lhu:
-+; CHECK: lhu {{[a-z0-9]+}}, 10(a0)
 +; CHECK: lhu {{[a-z0-9]+}}, 0(a0)
++; CHECK: lhu {{[a-z0-9]+}}, 10(a0)
 +  %1 = getelementptr i16, i16* %a, i32 5
 +  %2 = load i16, i16* %1
 +  %3 = zext i16 %2 to i32
@@ -524,8 +524,8 @@ index 00000000000..396498ebcd0
 +
 +define void @sb(i8 *%a, i8 %b) nounwind {
 +; CHECK-LABEL: sb:
-+; CHECK: sb a1, 0(a0)
 +; CHECK: sb a1, 6(a0)
++; CHECK: sb a1, 0(a0)
 +  store i8 %b, i8* %a
 +  %1 = getelementptr i8, i8* %a, i32 6
 +  store i8 %b, i8* %1
@@ -534,8 +534,8 @@ index 00000000000..396498ebcd0
 +
 +define void @sh(i16 *%a, i16 %b) nounwind {
 +; CHECK-LABEL: sh:
-+; CHECK: sh a1, 0(a0)
 +; CHECK: sh a1, 14(a0)
++; CHECK: sh a1, 0(a0)
 +  store i16 %b, i16* %a
 +  %1 = getelementptr i16, i16* %a, i32 7
 +  store i16 %b, i16* %1
@@ -544,8 +544,8 @@ index 00000000000..396498ebcd0
 +
 +define void @sw(i32 *%a, i32 %b) nounwind {
 +; CHECK-LABEL: sw:
-+; CHECK: sw a1, 0(a0)
 +; CHECK: sw a1, 32(a0)
++; CHECK: sw a1, 0(a0)
 +  store i32 %b, i32* %a
 +  %1 = getelementptr i32, i32* %a, i32 8
 +  store i32 %b, i32* %1

--- a/0015-RISCV-Support-for-function-calls.patch
+++ b/0015-RISCV-Support-for-function-calls.patch
@@ -36,7 +36,7 @@ diff --git a/lib/Target/RISCV/RISCVISelLowering.cpp b/lib/Target/RISCV/RISCVISel
 index 000618092b7..42d9d599461 100644
 --- a/lib/Target/RISCV/RISCVISelLowering.cpp
 +++ b/lib/Target/RISCV/RISCVISelLowering.cpp
-@@ -149,6 +149,136 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
+@@ -149,6 +149,134 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
    return Chain;
  }
  
@@ -71,9 +71,7 @@ index 000618092b7..42d9d599461 100644
 +  // Get a count of how many bytes are to be pushed on the stack.
 +  unsigned NumBytes = ArgCCInfo.getNextStackOffset();
 +
-+  Chain = DAG.getCALLSEQ_START(Chain,
-+                                 DAG.getIntPtrConstant(NumBytes, DL, true),
-+                                 DL);
++  Chain = DAG.getCALLSEQ_START(Chain, NumBytes, 0, DL);
 +
 +  // Copy argument values to their designated locations.
 +  SmallVector<std::pair<unsigned, SDValue>, 8> RegsToPass;
@@ -222,11 +220,12 @@ diff --git a/lib/Target/RISCV/RISCVInstrInfo.td b/lib/Target/RISCV/RISCVInstrInf
 index 6846cb428ab..4edf5cb3537 100644
 --- a/lib/Target/RISCV/RISCVInstrInfo.td
 +++ b/lib/Target/RISCV/RISCVInstrInfo.td
-@@ -13,8 +13,21 @@
+@@ -13,8 +13,22 @@
  
  include "RISCVInstrFormats.td"
  
-+def SDT_RISCVCallSeqStart : SDCallSeqStart<[SDTCisVT<0, i32>]>;
++def SDT_RISCVCallSeqStart : SDCallSeqStart<[SDTCisVT<0, i32>,
++                                            SDTCisVT<1, i32>]>;
 +def SDT_RISCVCallSeqEnd   : SDCallSeqEnd<[SDTCisVT<0, i32>,
 +                                         SDTCisVT<1, i32>]>;
 +def SDT_RISCVCall         : SDTypeProfile<0, -1, [SDTCisVT<0, i32>]>;
@@ -275,8 +274,8 @@ index 6846cb428ab..4edf5cb3537 100644
  
 +// Pessimstically assume the stack pointer will be clobbered
 +let Defs = [X2_32], Uses = [X2_32] in {
-+  def ADJCALLSTACKDOWN : Pseudo<(outs), (ins i32imm:$amt),
-+                                [(CallSeqStart timm:$amt)]>;
++  def ADJCALLSTACKDOWN : Pseudo<(outs), (ins i32imm:$amt1, i32imm:$amt2),
++                                [(CallSeqStart timm:$amt1, timm:$amt2)]>;
 +  def ADJCALLSTACKUP   : Pseudo<(outs), (ins i32imm:$amt1, i32imm:$amt2),
 +                                [(CallSeqEnd timm:$amt1, timm:$amt2)]>;
 +}

--- a/0017-RISCV-Support-and-tests-for-a-variety-of-additional-.patch
+++ b/0017-RISCV-Support-and-tests-for-a-variety-of-additional-.patch
@@ -191,16 +191,18 @@ new file mode 100644
 index 00000000000..1945a1aa40a
 --- /dev/null
 +++ b/test/CodeGen/RISCV/addc-adde-sube-subc.ll
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,22 @@
 +; RUN: llc -mtriple=riscv32 -verify-machineinstrs < %s | FileCheck %s
 +
 +; Ensure that the ISDOpcodes ADDC, ADDE, SUBC, SUBE are handled correctly
 +
 +define i64 @addc_adde(i64 %a, i64 %b) {
 +; CHECK-LABEL: addc_adde:
-+; CHECK: addi a5, zero, 1
-+; CHECK: bltu a0, a2, .LBB0_2
-+; CHECK: sltu a5, a0, a4
++; CHECK: add a1, a1, a3
++; CHECK: add a2, a0, a2
++; CHECK: sltu a0, a2, a0
++; CHECK: add a1, a1, a0
++; CHECK: addi a0, a2, 0
 +  %1 = add i64 %a, %b
 +  ret i64 %1
 +}


### PR DESCRIPTION
This updates the full RISC-V patch series to build on top of rL308291.

I've updated all the patches so that they apply, and fixed the tests such that everything passes with a make check.