### PR TITLE
[WIP] Patches for cross compiling rust's libcore.

### DIFF
--- a/0024-Add-support-for-BSWAP-intrinsic.patch
+++ b/0024-Add-support-for-BSWAP-intrinsic.patch
@@ -1,0 +1,56 @@
+From ea62d7c2a72d71b88caa45298e18ad9280ebfe04 Mon Sep 17 00:00:00 2001
+From: David Craven <david@craven.ch>
+Date: Wed, 9 Aug 2017 16:07:26 +0200
+Subject: [PATCH 1/4] Add support for BSWAP intrinsic.
+
+---
+ lib/Target/RISCV/RISCVISelLowering.cpp |  1 +
+ test/CodeGen/RISCV/bswap.ll            | 23 +++++++++++++++++++++++
+ 2 files changed, 24 insertions(+)
+ create mode 100644 test/CodeGen/RISCV/bswap.ll
+
+diff --git a/lib/Target/RISCV/RISCVISelLowering.cpp b/lib/Target/RISCV/RISCVISelLowering.cpp
+index c755d2ae321..13db2a1d9df 100644
+--- a/lib/Target/RISCV/RISCVISelLowering.cpp
++++ b/lib/Target/RISCV/RISCVISelLowering.cpp
+@@ -90,6 +90,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
+   setOperationAction(ISD::CTTZ, MVT::i32, Expand);
+   setOperationAction(ISD::CTLZ, MVT::i32, Expand);
+   setOperationAction(ISD::CTPOP, MVT::i32, Expand);
++  setOperationAction(ISD::BSWAP, MVT::i32, Expand);
+ 
+   setOperationAction(ISD::GlobalAddress, MVT::i32, Custom);
+ 
+diff --git a/test/CodeGen/RISCV/bswap.ll b/test/CodeGen/RISCV/bswap.ll
+new file mode 100644
+index 00000000000..467176cc42b
+--- /dev/null
++++ b/test/CodeGen/RISCV/bswap.ll
+@@ -0,0 +1,23 @@
++; RUN: llc -mtriple=riscv32 -verify-machineinstrs < %s | FileCheck %s
++
++declare i16 @llvm.bswap.i16(i16)
++declare i32 @llvm.bswap.i32(i32)
++declare i64 @llvm.bswap.i64(i64)
++
++define i16 @test_bswap_i16(i16 %a) {
++; CHECK-LABEL: test_bswap_i16:
++  %tmp = call i16 @llvm.bswap.i16(i16 %a)
++  ret i16 %tmp
++}
++
++define i32 @test_bswap_i32(i32 %a) {
++; CHECK-LABEL: test_bswap_i32:
++  %tmp = call i32 @llvm.bswap.i32(i32 %a)
++  ret i32 %tmp
++}
++
++define i64 @test_bswap_i64(i64 %a) {
++; CHECK-LABEL: test_bswap_i64:
++  %tmp = call i64 @llvm.bswap.i64(i64 %a)
++  ret i64 %tmp
++}
+\ No newline at end of file
+-- 
+2.11.1
+

--- a/0025-Calling-convention-return-i128.patch
+++ b/0025-Calling-convention-return-i128.patch
@@ -1,0 +1,39 @@
+From 209e7b4f26524540c49cc268a870864a47a15887 Mon Sep 17 00:00:00 2001
+From: David Craven <david@craven.ch>
+Date: Mon, 14 Aug 2017 08:43:51 +0200
+Subject: [PATCH 2/4] Calling convention return i128.
+
+---
+ lib/Target/RISCV/RISCVCallingConv.td | 2 +-
+ test/CodeGen/RISCV/calling-conv.ll   | 5 +++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lib/Target/RISCV/RISCVCallingConv.td b/lib/Target/RISCV/RISCVCallingConv.td
+index 51a4470f5ca..3a07c8f86ee 100644
+--- a/lib/Target/RISCV/RISCVCallingConv.td
++++ b/lib/Target/RISCV/RISCVCallingConv.td
+@@ -12,7 +12,7 @@
+ //===----------------------------------------------------------------------===//
+ 
+ // RISCV 32-bit C return-value convention.
+-def RetCC_RISCV32 : CallingConv<[CCIfType<[i32], CCAssignToReg<[X10_32, X11_32]>>]>;
++def RetCC_RISCV32 : CallingConv<[CCIfType<[i32], CCAssignToReg<[X10_32, X11_32, X12_32, X13_32]>>]>;
+ 
+ // RISCV 32-bit C Calling convention.
+ def CC_RISCV32 : CustomCallingConv;
+diff --git a/test/CodeGen/RISCV/calling-conv.ll b/test/CodeGen/RISCV/calling-conv.ll
+index 274993dd690..03bad378e52 100644
+--- a/test/CodeGen/RISCV/calling-conv.ll
++++ b/test/CodeGen/RISCV/calling-conv.ll
+@@ -360,3 +360,8 @@ define i32 @caller_large_struct_ret() {
+   %6 = add i32 %3, %5
+   ret i32 %6
+ }
++
++define i128 @caller_i128_ret() {
++; CHECK-LABEL: caller_i128_ret:
++  ret i128 0
++}
+-- 
+2.11.1
+

--- a/0026-Stack-adjustment-outside-12-bit-range.patch
+++ b/0026-Stack-adjustment-outside-12-bit-range.patch
@@ -1,0 +1,259 @@
+From ba6c5ca42704e94bd47caad69e50ac1bf929fc4e Mon Sep 17 00:00:00 2001
+From: David Craven <david@craven.ch>
+Date: Sat, 12 Aug 2017 18:09:28 +0200
+Subject: [PATCH 3/4] Stack adjustment outside 12-bit range.
+
+---
+ lib/Target/RISCV/RISCVFrameLowering.cpp | 90 ++++++++++++++++++++++++++++-----
+ lib/Target/RISCV/RISCVRegisterInfo.cpp  | 31 +++++++++++-
+ lib/Target/RISCV/RISCVRegisterInfo.h    | 10 ++++
+ test/CodeGen/RISCV/frame.ll             | 35 +++++++++++++
+ 4 files changed, 150 insertions(+), 16 deletions(-)
+
+diff --git a/lib/Target/RISCV/RISCVFrameLowering.cpp b/lib/Target/RISCV/RISCVFrameLowering.cpp
+index c1b38d6f101..23c211e1ac5 100644
+--- a/lib/Target/RISCV/RISCVFrameLowering.cpp
++++ b/lib/Target/RISCV/RISCVFrameLowering.cpp
+@@ -17,6 +17,7 @@
+ #include "llvm/CodeGen/MachineFunction.h"
+ #include "llvm/CodeGen/MachineInstrBuilder.h"
+ #include "llvm/CodeGen/MachineRegisterInfo.h"
++#include "llvm/CodeGen/RegisterScavenging.h"
+ 
+ using namespace llvm;
+ 
+@@ -87,16 +88,28 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
+   if (StackSize == 0 && !MFI.adjustsStack())
+     return;
+ 
+-  if (!isInt<12>(StackSize)) {
+-    llvm_unreachable("Stack adjustment won't fit in signed 12-bit immediate");
+-  }
+-
+   // Allocate space on the stack if necessary
+   if (StackSize != 0) {
+-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), SPReg)
++    if (isInt<12>(StackSize)) {
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), SPReg)
+         .addReg(SPReg)
+         .addImm(-StackSize)
+         .setMIFlag(MachineInstr::FrameSetup);
++    } else {
++      auto &MRI = MF.getRegInfo();
++      unsigned Reg = MRI.createVirtualRegister(&RISCV::GPRRegClass);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::LUI), Reg)
++        .addImm(StackSize & 0xFFFFF000)
++        .setMIFlag(MachineInstr::FrameSetup);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), Reg)
++        .addReg(Reg)
++        .addImm(StackSize & 0xFFF)
++        .setMIFlag(MachineInstr::FrameSetup);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::SUB), SPReg)
++        .addReg(SPReg)
++        .addReg(Reg)
++        .setMIFlag(MachineInstr::FrameSetup);
++    }
+   }
+ 
+   // The frame pointer is callee-saved, and code has been generated for us to
+@@ -109,10 +122,28 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
+   }
+ 
+   // Generate new FP
+-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), FPReg)
++  if (isInt<12>(StackSize)) {
++    BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), FPReg)
+       .addReg(SPReg)
+       .addImm(StackSize)
+       .setMIFlag(MachineInstr::FrameSetup);
++  } else {
++    // FIXME: Reg needs to be loaded twice since we don't
++    // know if x5 was modified when saving fp to the stack.
++    auto &MRI = MF.getRegInfo();
++    unsigned Reg = MRI.createVirtualRegister(&RISCV::GPRRegClass);
++    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LUI), Reg)
++      .addImm(StackSize & 0xFFFFF000)
++      .setMIFlag(MachineInstr::FrameSetup);
++    BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), Reg)
++      .addReg(Reg)
++      .addImm(StackSize & 0xFFF)
++      .setMIFlag(MachineInstr::FrameSetup);
++    BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADD), FPReg)
++      .addReg(SPReg)
++      .addReg(Reg)
++      .setMIFlag(MachineInstr::FrameSetup);
++  }
+ }
+ 
+ void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
+@@ -151,15 +182,29 @@ void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
+         .setMIFlag(MachineInstr::FrameDestroy);
+   }
+ 
+-  if (!isInt<12>(StackSize)) {
+-    llvm_unreachable("Stack adjustment won't fit in signed 12-bit immediate");
+-  }
+-
+   // Deallocate stack
+-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), SPReg)
+-      .addReg(SPReg)
+-      .addImm(StackSize)
+-      .setMIFlag(MachineInstr::FrameDestroy);
++  if (StackSize != 0) {
++    if (isInt<12>(StackSize)) {
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), SPReg)
++        .addReg(SPReg)
++        .addImm(StackSize)
++        .setMIFlag(MachineInstr::FrameDestroy);
++    } else {
++      auto &MRI = MF.getRegInfo();
++      unsigned Reg = MRI.createVirtualRegister(&RISCV::GPRRegClass);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::LUI), Reg)
++        .addImm(StackSize & 0xFFFFF000)
++        .setMIFlag(MachineInstr::FrameDestroy);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADDI), Reg)
++        .addReg(Reg)
++        .addImm(StackSize & 0xFFF)
++        .setMIFlag(MachineInstr::FrameDestroy);
++      BuildMI(MBB, MBBI, DL, TII->get(RISCV::ADD), SPReg)
++        .addReg(SPReg)
++        .addReg(Reg)
++        .setMIFlag(MachineInstr::FrameDestroy);
++    }
++  }
+ }
+ 
+ void RISCVFrameLowering::determineCalleeSaves(MachineFunction &MF,
+@@ -167,5 +212,22 @@ void RISCVFrameLowering::determineCalleeSaves(MachineFunction &MF,
+                                               RegScavenger *RS) const {
+   TargetFrameLowering::determineCalleeSaves(MF, SavedRegs, RS);
+   SavedRegs.set(RISCV::X8_32);
++
++  MachineFrameInfo &MFI = MF.getFrameInfo();
++  // The CSR spill slots have not been allocated yet, so estimateStackSize
++  // won't include them.
++  uint64_t MaxSPOffset = MFI.estimateStackSize(MF) + 8 * SavedRegs.count();
++
++  // Allocate emergency spill slot when necessary.
++  // TODO: Don't allocate when a spill register is available.
++  if (!isInt<12>(MaxSPOffset)) {
++    const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
++    const TargetRegisterClass &RC = RISCV::GPRRegClass;
++    unsigned Size = TRI->getSpillSize(RC);
++    unsigned Align = TRI->getSpillAlignment(RC);
++    int FI = MFI.CreateSpillStackObject(Size, Align);
++    RS->addScavengingFrameIndex(FI);
++  }
++
+   return;
+ }
+diff --git a/lib/Target/RISCV/RISCVRegisterInfo.cpp b/lib/Target/RISCV/RISCVRegisterInfo.cpp
+index 4a0373ff155..5241089c596 100644
+--- a/lib/Target/RISCV/RISCVRegisterInfo.cpp
++++ b/lib/Target/RISCV/RISCVRegisterInfo.cpp
+@@ -121,8 +121,35 @@ void RISCVRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
+       llvm_unreachable("Unexpected opcode");
+     }
+   } else {
+-    llvm_unreachable(
+-        "Frame offsets outside of the signed 12-bit range not supported");
++    auto &MRI = MF.getRegInfo();
++    unsigned OffsetReg = MRI.createVirtualRegister(&RISCV::GPRRegClass);
++
++    BuildMI(MBB, II, DL, TII->get(RISCV::LUI), OffsetReg)
++        .addImm(Offset & 0xFFFFF000);
++    BuildMI(MBB, II, DL, TII->get(RISCV::ADD), OffsetReg)
++        .addReg(OffsetReg)
++        .addReg(FrameReg);
++
++    switch (MI.getOpcode()) {
++    case RISCV::LW_FI:
++      BuildMI(MBB, II, DL, TII->get(RISCV::LW), Reg)
++          .addReg(OffsetReg)
++          .addImm(Offset & 0xFFF);
++      break;
++    case RISCV::SW_FI:
++      BuildMI(MBB, II, DL, TII->get(RISCV::SW))
++          .addReg(Reg, getKillRegState(MI.getOperand(0).isKill()))
++          .addReg(OffsetReg)
++          .addImm(Offset & 0xFFF);
++      break;
++    case RISCV::LEA_FI:
++      BuildMI(MBB, II, DL, TII->get(RISCV::ADDI), Reg)
++          .addReg(OffsetReg)
++          .addImm(Offset & 0xFFF);
++      break;
++    default:
++      llvm_unreachable("Unexpected opcode");
++    }
+   }
+ 
+   // Erase old instruction.
+diff --git a/lib/Target/RISCV/RISCVRegisterInfo.h b/lib/Target/RISCV/RISCVRegisterInfo.h
+index 159b9d5bd9b..9eab53cfbb0 100644
+--- a/lib/Target/RISCV/RISCVRegisterInfo.h
++++ b/lib/Target/RISCV/RISCVRegisterInfo.h
+@@ -39,6 +39,16 @@ struct RISCVRegisterInfo : public RISCVGenRegisterInfo {
+                            RegScavenger *RS = nullptr) const override;
+ 
+   unsigned getFrameRegister(const MachineFunction &MF) const override;
++
++  bool requiresRegisterScavenging(const MachineFunction &) const override {
++    return true;
++  }
++  bool trackLivenessAfterRegAlloc(const MachineFunction &) const override {
++    return true;
++  }
++  bool requiresFrameIndexScavenging(const MachineFunction &) const override {
++    return true;
++  }
+ };
+ }
+ 
+diff --git a/test/CodeGen/RISCV/frame.ll b/test/CodeGen/RISCV/frame.ll
+index 2451567b5fe..1551e1281ea 100644
+--- a/test/CodeGen/RISCV/frame.ll
++++ b/test/CodeGen/RISCV/frame.ll
+@@ -36,3 +36,38 @@ define i32 @test() {
+ declare void @llvm.memset.p0i8.i64(i8* nocapture, i8, i64, i32, i1)
+ 
+ declare void @test1(i8*)
++
++
++%struct.large_t = type { [4096 x i8] }
++
++; Function Attrs: nounwind uwtable
++define i32 @test2() {
++; CHECK-LABEL: test2:
++;; Adjust stack pointer
++;; 4096 + ?? + fp
++; CHECK: lui a0, 4096
++; CHECK: addi a0, a0, 8
++; CHECK: sub sp, sp, a0
++;; Save frame pointer (s0)
++; CHECK: lui a0, 4096
++; CHECK: add a0, a0, sp
++; CHECK: sw s0, 4(a0)
++;; Adjust frame pointer (s0)
++; CHECK: lui a0, 4096
++; CHECK: addi a0, a0, 8
++; CHECK: add s0, sp, a0
++;; Set return value to 0
++; CHECK: addi a0, zero, 0
++;; Load frame pointer (s0)
++; CHECK: lui a1, 4096
++; CHECK: add a1, a1, sp
++; CHECK: lw s0, 4(a1)
++;; Reset stack pointer
++; CHECK: lui a1, 4096
++; CHECK: addi a1, a1, 8
++; CHECK: add sp, sp, a1
++;; Return
++; CHECK: jalr zero, ra, 0
++  %large = alloca %struct.large_t, align 4
++  ret i32 0
++}
+\ No newline at end of file
+-- 
+2.11.1
+

--- a/0027-Add-M-Instructions.patch
+++ b/0027-Add-M-Instructions.patch
@@ -1,0 +1,222 @@
+From 529fb6b8fc2635a1039a7efc7cc10b1b27fd7683 Mon Sep 17 00:00:00 2001
+From: David Craven <david@craven.ch>
+Date: Wed, 9 Aug 2017 10:06:52 +0200
+Subject: [PATCH 4/4] Add M Instructions.
+
+---
+ lib/Target/RISCV/RISCV.td              |  3 ++
+ lib/Target/RISCV/RISCVISelLowering.cpp | 26 +++++++++++-----
+ lib/Target/RISCV/RISCVInstrInfo.td     | 11 +++++++
+ lib/Target/RISCV/RISCVSubtarget.h      |  2 ++
+ test/CodeGen/RISCV/m-extension.ll      | 54 ++++++++++++++++++++++++++++++++++
+ test/MC/RISCV/rv32im-valid.s           | 41 ++++++++++++++++++++++++++
+ 6 files changed, 129 insertions(+), 8 deletions(-)
+ create mode 100644 test/CodeGen/RISCV/m-extension.ll
+ create mode 100644 test/MC/RISCV/rv32im-valid.s
+
+diff --git a/lib/Target/RISCV/RISCV.td b/lib/Target/RISCV/RISCV.td
+index 8bdd4b19c4c..9e046ca8c3f 100644
+--- a/lib/Target/RISCV/RISCV.td
++++ b/lib/Target/RISCV/RISCV.td
+@@ -19,6 +19,9 @@ def RISCVInstrInfo : InstrInfo;
+ def Feature64Bit   : SubtargetFeature<"64bit", "HasRV64", "true",
+                                       "Implements RV64">;
+ 
++def FeatureM       : SubtargetFeature<"m", "HasM", "true",
++                                      "Implements M extension">;
++
+ def : ProcessorModel<"generic-rv32", NoSchedModel, []>;
+ 
+ def : ProcessorModel<"generic-rv64", NoSchedModel, [Feature64Bit]>;
+diff --git a/lib/Target/RISCV/RISCVISelLowering.cpp b/lib/Target/RISCV/RISCVISelLowering.cpp
+index 13db2a1d9df..fb6812ab704 100644
+--- a/lib/Target/RISCV/RISCVISelLowering.cpp
++++ b/lib/Target/RISCV/RISCVISelLowering.cpp
+@@ -68,18 +68,28 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
+   setOperationAction(ISD::SUBC, MVT::i32, Expand);
+   setOperationAction(ISD::SUBE, MVT::i32, Expand);
+ 
+-  setOperationAction(ISD::SREM, MVT::i32, Expand);
++  if (!Subtarget->hasM()) {
++    setOperationAction(ISD::MUL, MVT::i32, Expand);
++    setOperationAction(ISD::MULHS, MVT::i32, Expand);
++    setOperationAction(ISD::MULHU, MVT::i32, Expand);
++    setOperationAction(ISD::SDIV, MVT::i32, Expand);
++    setOperationAction(ISD::UDIV, MVT::i32, Expand);
++    setOperationAction(ISD::SREM, MVT::i32, Expand);
++    setOperationAction(ISD::UREM, MVT::i32, Expand);
++  } else {
++    setOperationAction(ISD::MUL, MVT::i32, Legal);
++    setOperationAction(ISD::MULHS, MVT::i32, Legal);
++    setOperationAction(ISD::MULHU, MVT::i32, Legal);
++    setOperationAction(ISD::SDIV, MVT::i32, Legal);
++    setOperationAction(ISD::UDIV, MVT::i32, Legal);
++    setOperationAction(ISD::SREM, MVT::i32, Legal);
++    setOperationAction(ISD::UREM, MVT::i32, Legal);
++  }
++
+   setOperationAction(ISD::SDIVREM, MVT::i32, Expand);
+-  setOperationAction(ISD::SDIV, MVT::i32, Expand);
+-  setOperationAction(ISD::UREM, MVT::i32, Expand);
+   setOperationAction(ISD::UDIVREM, MVT::i32, Expand);
+-  setOperationAction(ISD::UDIV, MVT::i32, Expand);
+-
+-  setOperationAction(ISD::MUL, MVT::i32, Expand);
+   setOperationAction(ISD::SMUL_LOHI, MVT::i32, Expand);
+   setOperationAction(ISD::UMUL_LOHI, MVT::i32, Expand);
+-  setOperationAction(ISD::MULHS, MVT::i32, Expand);
+-  setOperationAction(ISD::MULHU, MVT::i32, Expand);
+ 
+   setOperationAction(ISD::SHL_PARTS, MVT::i32, Expand);
+   setOperationAction(ISD::SRL_PARTS, MVT::i32, Expand);
+diff --git a/lib/Target/RISCV/RISCVInstrInfo.td b/lib/Target/RISCV/RISCVInstrInfo.td
+index 7d8670dc6ae..2bef1684464 100644
+--- a/lib/Target/RISCV/RISCVInstrInfo.td
++++ b/lib/Target/RISCV/RISCVInstrInfo.td
+@@ -361,3 +361,14 @@ def : Pat<(simm12:$imm), (ADDI X0_32, simm12:$imm)>;
+ 
+ // 32-bit immediate
+ def : Pat<(i32 imm:$imm), (ADDI (LUI (HI20 imm:$imm)), (LO12Sext imm:$imm))>;
++
++
++def MUL     : ALU_rr<0b0000001, 0b000, "mul", mul>;
++def MULH    : ALU_rr<0b0000001, 0b001, "mulh", mulhs>;
++// NOTE: no corresponding llvm ir instruction
++def MULHSU  : ALU_rr<0b0000001, 0b010, "mulhsu", mulhs>;
++def MULHU   : ALU_rr<0b0000001, 0b011, "mulhu", mulhu>;
++def DIV     : ALU_rr<0b0000001, 0b100, "div", sdiv>;
++def DIVU    : ALU_rr<0b0000001, 0b101, "divu", udiv>;
++def REM     : ALU_rr<0b0000001, 0b110, "rem", srem>;
++def REMU    : ALU_rr<0b0000001, 0b111, "remu", urem>;
+\ No newline at end of file
+diff --git a/lib/Target/RISCV/RISCVSubtarget.h b/lib/Target/RISCV/RISCVSubtarget.h
+index 3db2ef9742f..65806bb1e1b 100644
+--- a/lib/Target/RISCV/RISCVSubtarget.h
++++ b/lib/Target/RISCV/RISCVSubtarget.h
+@@ -35,6 +35,7 @@ class RISCVSubtarget : public RISCVGenSubtargetInfo {
+   RISCVTargetLowering TLInfo;
+   SelectionDAGTargetInfo TSInfo;
+   bool HasRV64;
++  bool HasM;
+ 
+ public:
+   // Initializes the data members to match that of the specified triple.
+@@ -59,6 +60,7 @@ public:
+     return &TSInfo;
+   }
+   bool is64Bit() const { return HasRV64; }
++  bool hasM() const { return HasM; }
+ };
+ } // End llvm namespace
+ 
+diff --git a/test/CodeGen/RISCV/m-extension.ll b/test/CodeGen/RISCV/m-extension.ll
+new file mode 100644
+index 00000000000..40abe135589
+--- /dev/null
++++ b/test/CodeGen/RISCV/m-extension.ll
+@@ -0,0 +1,54 @@
++; RUN: llc -mtriple=riscv32 -mattr=m -verify-machineinstrs < %s | FileCheck %s
++
++define i32 @square(i32 %a) {
++; CHECK-LABEL: square:
++; CHECK: mul a0, a0, a0
++; CHECK: jalr zero, ra, 0
++  %1 = mul i32 %a, %a
++  ret i32 %1
++}
++
++define i32 @mul(i32 %a, i32 %b) {
++; CHECK-LABEL: mul:
++; CHECK: mul a0, a0, a1
++; CHECK: jalr zero, ra, 0
++  %1 = mul i32 %a, %b
++  ret i32 %1
++}
++
++define i32 @mul_constant(i32 %a) {
++; CHECK-LABEL: mul_constant:
++; CHECK: addi a1, zero, 5
++; CHECK: mul a0, a0, a1
++; CHECK: jalr zero, ra, 0
++  %1 = mul i32 %a, 5
++  ret i32 %1
++}
++
++define i32 @mul_pow2(i32 %a) {
++; CHECK-LABEL: mul_pow2:
++; CHECK: slli a0, a0, 3
++; CHECK: jalr zero, ra, 0
++  %1 = mul i32 %a, 8
++  ret i32 %1
++}
++
++define i64 @mul64(i64 %a, i64 %b) {
++; CHECK-LABEL: mul64:
++; CHECK: lui a4, %hi(__muldi3)
++; CHECK: addi a4, a4, %lo(__muldi3)
++; CHECK: jalr ra, a4, 0
++  %1 = mul i64 %a, %b
++  ret i64 %1
++}
++
++define i64 @mul64_constant(i64 %a) {
++; CHECK-LABEL: mul64_constant:
++; CHECK: lui a2, %hi(__muldi3)
++; CHECK: addi a4, a2, %lo(__muldi3)
++; CHECK: addi a2, zero, 5
++; CHECK: addi a3, zero, 0
++; CHECK: jalr ra, a4, 0
++  %1 = mul i64 %a, 5
++  ret i64 %1
++}
+\ No newline at end of file
+diff --git a/test/MC/RISCV/rv32im-valid.s b/test/MC/RISCV/rv32im-valid.s
+new file mode 100644
+index 00000000000..2fe7ed725e2
+--- /dev/null
++++ b/test/MC/RISCV/rv32im-valid.s
+@@ -0,0 +1,41 @@
++# RUN: llvm-mc %s -triple=riscv32 -show-encoding \
++# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-INST %s
++# RUN: llvm-mc %s -triple=riscv64 -show-encoding \
++# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-INST %s
++# RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
++# RUN:     | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
++# RUN: llvm-mc -filetype=obj -triple riscv64 < %s \
++# RUN:     | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
++
++
++# CHECK-INST: mul ra, zero, zero
++# CHECK: encoding: [0xb3,0x00,0x00,0x02]
++mul x1, x0, x0
++
++# CHECK-INST: mulh ra, zero, zero
++# CHECK: encoding: [0xb3,0x10,0x00,0x02]
++mulh x1, x0, x0
++
++# CHECK-INST: mulhsu ra, zero, zero
++# CHECK: encoding: [0xb3,0x20,0x00,0x02]
++mulhsu x1, x0, x0
++
++# CHECK-INST: mulhu ra, zero, zero
++# CHECK: encoding: [0xb3,0x30,0x00,0x02]
++mulhu x1, x0, x0
++
++# CHECK-INST: div ra, zero, zero
++# CHECK: encoding: [0xb3,0x40,0x00,0x02]
++div x1, x0, x0
++
++# CHECK-INST: divu ra, zero, zero
++# CHECK: encoding: [0xb3,0x50,0x00,0x02]
++divu x1, x0, x0
++
++# CHECK-INST: rem ra, zero, zero
++# CHECK: encoding: [0xb3,0x60,0x00,0x02]
++rem x1, x0, x0
++
++# CHECK-INST: remu ra, zero, zero
++# CHECK: encoding: [0xb3,0x70,0x00,0x02]
++remu x1, x0, x0
+-- 
+2.11.1
+

--- a/lld/0001-Initial-RISCV-support.patch
+++ b/lld/0001-Initial-RISCV-support.patch
@@ -1,0 +1,334 @@
+From 65472178fb2c89a97c25c5be73243b4503bd3de5 Mon Sep 17 00:00:00 2001
+From: David Craven <david@craven.ch>
+Date: Tue, 8 Aug 2017 08:32:30 +0200
+Subject: [PATCH] Initial RISCV support.
+
+---
+ ELF/Arch/RISCV.cpp               | 100 +++++++++++++++++++++++++++++++++++++++
+ ELF/CMakeLists.txt               |   1 +
+ ELF/Driver.cpp                   |   2 +
+ ELF/InputFiles.cpp               |   3 ++
+ ELF/Target.cpp                   |   2 +
+ ELF/Target.h                     |   1 +
+ test/ELF/Inputs/riscv-foo.s      |  12 +++++
+ test/ELF/Inputs/riscv-foo.script |  10 ++++
+ test/ELF/riscv-relocs.s          |  85 +++++++++++++++++++++++++++++++++
+ test/lit.cfg                     |   2 +
+ 10 files changed, 218 insertions(+)
+ create mode 100644 ELF/Arch/RISCV.cpp
+ create mode 100644 test/ELF/Inputs/riscv-foo.s
+ create mode 100644 test/ELF/Inputs/riscv-foo.script
+ create mode 100644 test/ELF/riscv-relocs.s
+
+diff --git a/ELF/Arch/RISCV.cpp b/ELF/Arch/RISCV.cpp
+new file mode 100644
+index 000000000..8ac3d30bc
+--- /dev/null
++++ b/ELF/Arch/RISCV.cpp
+@@ -0,0 +1,100 @@
++//===- RISCV.cpp ---------------------------------------------------------===//
++//
++//                             The LLVM Linker
++//
++// This file is distributed under the University of Illinois Open Source
++// License. See LICENSE.TXT for details.
++//
++//===----------------------------------------------------------------------===//
++
++#include "Error.h"
++#include "InputFiles.h"
++#include "Symbols.h"
++#include "Target.h"
++#include "llvm/Object/ELF.h"
++#include "llvm/Support/Endian.h"
++
++using namespace llvm;
++using namespace llvm::object;
++using namespace llvm::support::endian;
++using namespace llvm::ELF;
++using namespace lld;
++using namespace lld::elf;
++
++namespace {
++class RISCV final : public TargetInfo {
++public:
++  void relocateOne(uint8_t *Loc, uint32_t Type, uint64_t Val) const override;
++  RelExpr getRelExpr(uint32_t Type, const SymbolBody &S,
++                     const InputFile &File,
++                     const uint8_t *Loc) const override;
++};
++} // namespace
++
++static void or32le(uint8_t *Loc, uint32_t Val) {
++  write32le(Loc, read32le(Loc) | Val);
++}
++
++RelExpr RISCV::getRelExpr(uint32_t Type, const SymbolBody &S,
++                          const InputFile &File, const uint8_t *Loc) const {
++  switch (Type) {
++  case R_RISCV_32:
++  case R_RISCV_64:
++  case R_RISCV_HI20:
++  case R_RISCV_LO12_I:
++  case R_RISCV_LO12_S:
++    return R_ABS;
++  case R_RISCV_PCREL_HI20:
++  case R_RISCV_JAL:
++  case R_RISCV_BRANCH:
++    return R_PC;
++  default:
++    error(toString(&File) + ": unknown relocation type: " + toString(Type));
++    return R_HINT;
++  }
++}
++
++void RISCV::relocateOne(uint8_t *Loc, uint32_t Type, uint64_t Val) const {
++  switch (Type) {
++  case R_RISCV_32:
++    checkIntUInt<32>(Loc, Val, Type);
++    write32le(Loc, Val);
++    break;
++  case R_RISCV_64:
++    write64le(Loc, Val);
++    break;
++  case R_RISCV_HI20:
++    checkUInt<32>(Loc, Val, Type);
++    or32le(Loc, Val & 0xFFFFF000);
++    break;
++  case R_RISCV_LO12_I:
++    checkUInt<32>(Loc, Val, Type);
++    or32le(Loc, (Val & 0xFFF) << 20);
++    break;
++  case R_RISCV_LO12_S:
++    checkUInt<32>(Loc, Val, Type);
++    or32le(Loc, ((Val & 0xFE0) << 20) | ((Val & 0x1F) << 7));
++    break;
++  case R_RISCV_PCREL_HI20:
++    checkInt<32>(Loc, Val, Type);
++    or32le(Loc, (Val + 0x1000) & 0xFFFFF000);
++    break;
++  case R_RISCV_JAL:
++    checkInt<21>(Loc, Val, Type);
++    or32le(Loc, ((Val & 0x100000) << 11) | ((Val & 0x7FE)   << 20)
++           |    ((Val & 0x800)    <<  9) | ((Val & 0xFF000) <<  0));
++    break;
++  case R_RISCV_BRANCH:
++    checkInt<13>(Loc, Val, Type);
++    or32le(Loc, ((Val & 0x1000) << 19) | ((Val & 0x7E0) << 20)
++           |    ((Val & 0x1E)   <<  7) | ((Val & 0x800) >>  4));
++    break;
++  default:
++    error(getErrorLocation(Loc) + "unrecognized reloc " + toString(Type));
++  }
++}
++
++TargetInfo *elf::getRISCVTargetInfo() {
++  static RISCV Target;
++  return &Target;
++}
+diff --git a/ELF/CMakeLists.txt b/ELF/CMakeLists.txt
+index 77243bd49..a9d71633d 100644
+--- a/ELF/CMakeLists.txt
++++ b/ELF/CMakeLists.txt
+@@ -15,6 +15,7 @@ add_lld_library(lldELF
+   Arch/MipsArchTree.cpp
+   Arch/PPC.cpp
+   Arch/PPC64.cpp
++  Arch/RISCV.cpp
+   Arch/SPARCV9.cpp
+   Arch/X86.cpp
+   Arch/X86_64.cpp
+diff --git a/ELF/Driver.cpp b/ELF/Driver.cpp
+index a52693b05..96c7af75d 100644
+--- a/ELF/Driver.cpp
++++ b/ELF/Driver.cpp
+@@ -111,6 +111,8 @@ static std::tuple<ELFKind, uint16_t, uint8_t> parseEmulation(StringRef Emul) {
+           .Cases("elf_amd64", "elf_x86_64", {ELF64LEKind, EM_X86_64})
+           .Case("elf_i386", {ELF32LEKind, EM_386})
+           .Case("elf_iamcu", {ELF32LEKind, EM_IAMCU})
++          .Case("elf32-riscv", {ELF32LEKind, EM_RISCV})
++          .Case("elf64-riscv", {ELF64LEKind, EM_RISCV})
+           .Default({ELFNoneKind, EM_NONE});
+ 
+   if (Ret.first == ELFNoneKind) {
+diff --git a/ELF/InputFiles.cpp b/ELF/InputFiles.cpp
+index 26caa4c2f..c609d4b16 100644
+--- a/ELF/InputFiles.cpp
++++ b/ELF/InputFiles.cpp
+@@ -810,6 +810,9 @@ static uint8_t getBitcodeMachineKind(StringRef Path, const Triple &T) {
+     return EM_PPC;
+   case Triple::ppc64:
+     return EM_PPC64;
++  case Triple::riscv32:
++  case Triple::riscv64:
++    return EM_RISCV;
+   case Triple::x86:
+     return T.isOSIAMCU() ? EM_IAMCU : EM_386;
+   case Triple::x86_64:
+diff --git a/ELF/Target.cpp b/ELF/Target.cpp
+index 11986efc7..2a29e6ad1 100644
+--- a/ELF/Target.cpp
++++ b/ELF/Target.cpp
+@@ -77,6 +77,8 @@ TargetInfo *elf::getTarget() {
+     return getPPCTargetInfo();
+   case EM_PPC64:
+     return getPPC64TargetInfo();
++  case EM_RISCV:
++    return getRISCVTargetInfo();
+   case EM_SPARCV9:
+     return getSPARCV9TargetInfo();
+   case EM_X86_64:
+diff --git a/ELF/Target.h b/ELF/Target.h
+index 7720e1b94..0874a6ac6 100644
+--- a/ELF/Target.h
++++ b/ELF/Target.h
+@@ -116,6 +116,7 @@ TargetInfo *getARMTargetInfo();
+ TargetInfo *getAVRTargetInfo();
+ TargetInfo *getPPC64TargetInfo();
+ TargetInfo *getPPCTargetInfo();
++TargetInfo *getRISCVTargetInfo();
+ TargetInfo *getSPARCV9TargetInfo();
+ TargetInfo *getX32TargetInfo();
+ TargetInfo *getX86TargetInfo();
+diff --git a/test/ELF/Inputs/riscv-foo.s b/test/ELF/Inputs/riscv-foo.s
+new file mode 100644
+index 000000000..0be4c2af2
+--- /dev/null
++++ b/test/ELF/Inputs/riscv-foo.s
+@@ -0,0 +1,12 @@
++  .section .text.foo.near
++	.globl foo_near
++
++foo_near:
++	addi zero, zero, 0
++
++
++	.section .text.foo.far
++	.globl foo_far
++
++foo_far:
++	addi zero, zero, 0
+diff --git a/test/ELF/Inputs/riscv-foo.script b/test/ELF/Inputs/riscv-foo.script
+new file mode 100644
+index 000000000..d0042980a
+--- /dev/null
++++ b/test/ELF/Inputs/riscv-foo.script
+@@ -0,0 +1,10 @@
++SECTIONS
++{
++  . = 0x11111000;
++  .text : {
++    *(.text.foo.far)
++    . = 0x11113000;
++    *(.text.foo.near)
++    *(.text.test)
++  }
++}
+\ No newline at end of file
+diff --git a/test/ELF/riscv-relocs.s b/test/ELF/riscv-relocs.s
+new file mode 100644
+index 000000000..340a528e5
+--- /dev/null
++++ b/test/ELF/riscv-relocs.s
+@@ -0,0 +1,85 @@
++# Check R_RISCV_* relocations calculation.
++
++# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-none %s -o %t1.o
++# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-none \
++# RUN:     %S/Inputs/riscv-foo.s -o %t2.o
++# RUN: ld.lld %t1.o %t2.o -o %t.exe -script %S/Inputs/riscv-foo.script
++# RUN: llvm-objdump -d -t -s %t.exe | FileCheck %s
++
++# REQUIRES: riscv
++
++# CHECK: foo_far:
++# CHECK: 11111000:	13 00 00 00 	addi	zero, zero, 0
++# CHECK: foo_near:
++# CHECK: 11113000:	13 00 00 00 	addi	zero, zero, 0
++
++  .section .text.test
++	.globl _start
++	.extern foo
++
++_start:
++	addi t1, t1, 0
++# CHECK: _start:
++# CHECK: 11113004:	13 03 03 00 	addi	t1, t1, 0
++
++R_RISCV_32:
++	.long foo_far
++# CHECK: R_RISCV_32:
++# CHECK: 11113008:	00 10 11 11  <unknown>
++
++R_RISCV_64:
++	.quad foo_far
++# CHECK: R_RISCV_64:
++# CHECK: 1111300c:	00 10 11 11  <unknown>
++# CHECK: 11113010:	00 00 00 00  <unknown>
++
++R_RISCV_HI20:
++	lui t1, %hi(foo_far)
++# CHECK: R_RISCV_HI20:
++# CHECK: 11113014:	37 13 11 11 	lui	t1, 69905
++
++R_RISCV_HI20_OFFSET:
++	lui t1, %hi(foo_far+4)
++# CHECK: R_RISCV_HI20_OFFSET:
++# CHECK: 11113018:	37 13 11 11 	lui	t1, 69905
++
++R_RISCV_LO12_I:
++	addi t1, t1, %lo(foo_far)
++# CHECK: R_RISCV_LO12_I:
++# CHECK: 1111301c:	13 03 03 00 	addi	t1, t1, 0
++
++R_RISCV_LO12_I_OFFSET:
++	addi t1, t1, %lo(foo_far+4)
++# CHECK: R_RISCV_LO12_I_OFFSET:
++# CHECK: 11113020:	13 03 43 00 	addi	t1, t1, 4
++
++R_RISCV_LO12_S:
++	sb t1, %lo(foo_far)(a2)
++# CHECK: R_RISCV_LO12_S:
++# CHECK: 11113024:	23 00 66 00 	sb	t1, 0(a2)
++
++R_RISCV_LO12_S_OFFSET:
++	sb t1, %lo(foo_far+4)(a2)
++# CHECK: R_RISCV_LO12_S_OFFSET:
++# CHECK: 11113028:	23 02 66 00 	sb	t1, 4(a2)
++
++
++R_RISCV_PCREL_HI20:
++	auipc t1, %pcrel_hi(foo_far)
++# CHECK: R_RISCV_PCREL_HI20:
++# CHECK: 1111302c:	17 e3 ff ff 	auipc	t1, 1048574
++
++R_RISCV_PCREL_HI20_OFFSET:
++	auipc t1, %pcrel_hi(foo_far+4)
++# CHECK: R_RISCV_PCREL_HI20_OFFSET:
++# CHECK: 11113030:	17 e3 ff ff 	auipc	t1, 1048574
++
++R_RISCV_JAL:
++	jal zero, foo_near
++# CHECK: R_RISCV_JAL:
++# CHECK: 11113034:	6f f0 df fc 	jal	zero, -52
++
++R_RISCV_BRANCH:
++	bgeu a0, a1, foo_near
++# CHECK: R_RISCV_BRANCH:
++# CHECK: 11113038:	e3 74 b5 fc 	bgeu	a0, a1, -56
+diff --git a/test/lit.cfg b/test/lit.cfg
+index 95bf3c0dc..f9413c653 100644
+--- a/test/lit.cfg
++++ b/test/lit.cfg
+@@ -255,6 +255,8 @@ if re.search(r'Mips', archs):
+     config.available_features.add('mips')
+ if re.search(r'PowerPC', archs):
+     config.available_features.add('ppc')
++if re.search(r'RISCV', archs):
++    config.available_features.add('riscv')
+ if re.search(r'Sparc', archs):
+     config.available_features.add('sparc')
+ if re.search(r'X86', archs):
+-- 
+2.11.1
+


### PR DESCRIPTION
Missing features to compile rust's libcore for RV32IMA:
- [x] bswap intrinsic
- [ ] return arguments through stack
- [x] Stack adjustment outside of 12-bit imm range
- [x] M extension
- [ ] A extension
- [x] Privileged instructions
- [x] insertBranch (required for optimizations)
- [x] lld: Implement relocations emitted by llvm