### PR TITLE
Fix path in build instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -108,7 +108,7 @@ guidance. You will need ~7GiB space for a debug build of LLVM+Clang.
 
     export REV=314102 # Check the most recent commit on this repo to ensure this is correct
     svn co http://llvm.org/svn/llvm-project/llvm/trunk@$REV llvm
-    cd tools
+    cd llvm/tools
     svn co http://llvm.org/svn/llvm-project/cfe/trunk@$REV clang
     cd ..
     for P in /path/to/riscv-llvm/*.patch; do patch -p1 < $P; done


### PR DESCRIPTION
This fixes one incorrect step.

Personally, I would just put the whole instructions in a format that you can copy and paste without change, for reduced friction:

	git clone https://github.com/lowRISC/riscv-llvm.git
	cd riscv-llvm
	export REV=314102
	svn co http://llvm.org/svn/llvm-project/llvm/trunk@$REV llvm
	cd llvm/tools
	svn co http://llvm.org/svn/llvm-project/cfe/trunk@$REV clang
	cd ..
	for P in ../*.patch; do patch -p1 < $P; done
	for P in ../clang/*.patch; do patch -d tools/clang -p1 < $P; done
	mkdir build
	cd build
	cmake -G Ninja -DCMAKE_BUILD_TYPE="Debug" \
	      -DBUILD_SHARED_LIBS=True -DLLVM_USE_SPLIT_DWARF=True \
	      -DLLVM_OPTIMIZED_TABLEGEN=True \
	      -DLLVM_BUILD_TESTS=True \
	      -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV" ../
	cmake --build .

(BTW, I don't know how important BUILD_SHARED_LIBS is but I had to remove for my work with LDC, so... maybe reconsider including it?)