### PR TITLE
DOC: fix comment tag to make the github preview to render correctly

### DIFF
--- a/docs/07-initial-codegen.mkd
+++ b/docs/07-initial-codegen.mkd
@@ -90,7 +90,7 @@ passed in, and create an appropriate virtual register. `LowerReturn` will copy
 the return value into the register appropriate for the target calling 
 convention.
 
-<!-- More info on RISCVISD::RET_FLAG --!>
+<!-- More info on RISCVISD::RET_FLAG -->
 
 ## Specifying the calling convention
 


### PR DESCRIPTION
Currently the last part of `07-initial-codegen.mkd` render on github preview is messy. This trivial PR fixes this.